### PR TITLE
[FEATURE] E#3-S5, S6 리뷰 텍스트 및 태그 입력 + 리뷰 작성완료

### DIFF
--- a/src/components/review/write/ReviewText.tsx
+++ b/src/components/review/write/ReviewText.tsx
@@ -1,0 +1,70 @@
+import React from 'react';
+import styled from 'styled-components';
+import { theme } from 'styles/theme';
+
+interface ReviewTextProps {
+  text: string;
+  handleTextChange: (e: React.ChangeEvent<HTMLTextAreaElement>) => void;
+}
+
+function ReviewText(props: ReviewTextProps) {
+  const { text, handleTextChange } = props;
+
+  return (
+    <StyledRoot>
+      <StyledTextArea
+        value={text}
+        onChange={handleTextChange}
+        placeholder="소품샵에 대한 후기를 자유롭게 작성해 주세요! (최소 35자, 최대 500자)"
+      />
+      <p>{`(${text.length}/500자)`}</p>
+    </StyledRoot>
+  );
+}
+
+const StyledRoot = styled.div`
+  width: 79.2rem;
+  height: 26rem;
+  background-color: ${theme.colors.grayBg};
+  padding: 1.7rem 0.8rem;
+  p {
+    font-size: 1.4rem;
+    font-weight: 500;
+    color: ${theme.colors.gray1};
+    float: right;
+    margin-right: 2.2rem;
+  }
+`;
+const StyledTextArea = styled.textarea`
+  width: 75.7rem;
+  height: 20rem;
+  outline: none;
+  border: none;
+  resize: none;
+  font-family: 'Noto Sans KR';
+  font-size: 1.4rem;
+  font-weight: 500;
+  background-color: ${theme.colors.grayBg};
+  margin-left: 1.9rem;
+  margin-top: 0.9rem;
+  padding-right: 1.8rem;
+  color: ${theme.colors.gray1};
+  &::placeholder {
+    color: ${theme.colors.gray1};
+  }
+  ::-webkit-scrollbar {
+    width: 0.5rem;
+  }
+  ::-webkit-scrollbar-track {
+    background: none;
+  }
+  ::-webkit-scrollbar-thumb {
+    background: rgba(140, 140, 149, 0.5);
+    border-radius: 0.25rem;
+    &:hover {
+      background: ${theme.colors.gray1};
+    }
+  }
+`;
+
+export default ReviewText;

--- a/src/components/review/write/SubmitButton.tsx
+++ b/src/components/review/write/SubmitButton.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import styled from 'styled-components';
+import { theme } from 'styles/theme';
+
+interface SubmitButtonProps {
+  isSubmitAvailable: boolean;
+  handleFormSubmit: () => void;
+}
+interface StyledProps {
+  isSubmitAvailable: boolean;
+}
+
+function SubmitButton(props: SubmitButtonProps) {
+  const { isSubmitAvailable, handleFormSubmit } = props;
+
+  return (
+    <StyledButton type="submit" onClick={handleFormSubmit} isSubmitAvailable={isSubmitAvailable}>
+      리뷰 작성완료
+    </StyledButton>
+  );
+}
+
+const StyledButton = styled.button<StyledProps>`
+  width: 79.2rem;
+  height: 5.9rem;
+  border-radius: 1rem;
+  border: none;
+  font-size: 1.8rem;
+  font-weight: bold;
+  color: white;
+  background-color: ${(props) =>
+    props.isSubmitAvailable ? theme.colors.purpleMain : theme.colors.gray2};
+  &:hover {
+    cursor: ${(props) => (props.isSubmitAvailable ? 'pointer' : 'default')};
+  }
+`;
+
+export default SubmitButton;

--- a/src/components/review/write/TagList.tsx
+++ b/src/components/review/write/TagList.tsx
@@ -1,0 +1,97 @@
+import React, { useState } from 'react';
+import styled from 'styled-components';
+import { theme } from 'styles/theme';
+
+interface TagListProps {
+  tags: string[];
+  handleTagSubmit: (data: string) => void;
+  handleTagDelete: (data: string) => void;
+}
+
+function TagList(props: TagListProps) {
+  const { tags, handleTagSubmit, handleTagDelete } = props;
+
+  const [input, setInput] = useState<string>('');
+
+  const handleTextChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    let data = e.target.value;
+    if (data.length > 8) {
+      data = data.slice(0, 8);
+    }
+    setInput(data);
+  };
+
+  const handleSubmit = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    const value = e.currentTarget.value;
+    if (e.key === ',' || e.key === 'Enter') {
+      if (value === '' || value === ' ' || tags.includes(value)) {
+        setInput('');
+        return;
+      }
+      if (tags.length < 4) {
+        handleTagSubmit(value);
+        setInput('');
+      }
+    }
+  };
+
+  return (
+    <StyledRoot>
+      {tags &&
+        tags.map((tag) => (
+          <StyledTag key={tag} onClick={() => handleTagDelete(tag)}>
+            {tag}
+          </StyledTag>
+        ))}
+      <StyledInput
+        type="text"
+        value={input}
+        onChange={handleTextChange}
+        onKeyPress={handleSubmit}
+        placeholder="#해시태그를 입력해주세요 (최대 8글자, 4개까지 추가 가능)"
+      />
+    </StyledRoot>
+  );
+}
+
+const StyledRoot = styled.div`
+  width: 79.2rem;
+  height: 4rem;
+  border-radius: 0.5rem;
+  border: 0.15rem solid ${theme.colors.gray2};
+  padding: 0.8rem 1.4rem;
+  display: flex;
+  align-items: center;
+`;
+const StyledInput = styled.input`
+  font-family: 'Noto Sans KR';
+  font-size: 1.4rem;
+  font-weight: 500;
+  color: ${theme.colors.gray1};
+  border: none;
+  flex: 1;
+  &::placeholder {
+    color: ${theme.colors.gray1};
+  }
+  &:focus {
+    outline: none;
+  }
+`;
+const StyledTag = styled.div`
+  font-size: 1.2rem;
+  font-weight: bold;
+  line-height: 2rem;
+  color: ${theme.colors.purpleText};
+  padding: 0.1rem 0.9rem;
+  height: 2.4rem;
+  border: 0.1rem solid ${theme.colors.purpleText};
+  border-radius: 3rem;
+  margin-right: 0.8rem;
+  &:hover {
+    cursor: pointer;
+    background-color: ${theme.colors.purpleText};
+    color: white;
+  }
+`;
+
+export default TagList;

--- a/src/components/review/write/TagList.tsx
+++ b/src/components/review/write/TagList.tsx
@@ -92,6 +92,10 @@ const StyledTag = styled.div`
     background-color: ${theme.colors.purpleText};
     color: white;
   }
+
+  &:before {
+    content: '#';
+  }
 `;
 
 export default TagList;

--- a/src/pages/review/write.tsx
+++ b/src/pages/review/write.tsx
@@ -1,6 +1,7 @@
 import PreviewImageList from 'components/review/write/PreviewImageList';
 import PreviewImageMain from 'components/review/write/PreviewImageMain';
 import ReviewText from 'components/review/write/ReviewText';
+import SubmitButton from 'components/review/write/SubmitButton';
 import TagList from 'components/review/write/TagList';
 import { useEffect, useState } from 'react';
 import { ReviewImage } from 'types/review';
@@ -18,8 +19,10 @@ function Write() {
   useEffect(() => {
     if (reviewImageList.length > 0 && reviewData.text.length >= 35) {
       setIsSubmitAvailable(true);
+    } else {
+      setIsSubmitAvailable(false);
     }
-  }, [reviewImageList, reviewData]);
+  }, [reviewImageList, reviewData.text]);
 
   const handleImageUpload = async (e: React.ChangeEvent<HTMLInputElement>) => {
     if (e.target.files === null) return;
@@ -103,6 +106,12 @@ function Write() {
     setReviewData(tempData);
   };
 
+  const handleFormSubmit = async () => {
+    if (isSubmitAvailable) {
+      console.log(reviewImageList, reviewData);
+    }
+  };
+
   return (
     <>
       <PreviewImageMain
@@ -122,6 +131,7 @@ function Write() {
         handleTagSubmit={handleTagSubmit}
         handleTagDelete={handleTagDelete}
       />
+      <SubmitButton isSubmitAvailable={isSubmitAvailable} handleFormSubmit={handleFormSubmit} />
     </>
   );
 }

--- a/src/pages/review/write.tsx
+++ b/src/pages/review/write.tsx
@@ -1,10 +1,24 @@
 import PreviewImageList from 'components/review/write/PreviewImageList';
 import PreviewImageMain from 'components/review/write/PreviewImageMain';
-import { useState } from 'react';
+import ReviewText from 'components/review/write/ReviewText';
+import { useEffect, useState } from 'react';
 import { ReviewImage } from 'types/review';
 
+interface ReviewData {
+  text: string;
+  tags: string[];
+}
+
 function Write() {
+  const [isSubmitAvailable, setIsSubmitAvailable] = useState(false);
   const [reviewImageList, setReviewImageList] = useState<ReviewImage[]>([]);
+  const [reviewData, setReviewData] = useState<ReviewData>({ text: '', tags: [] });
+
+  useEffect(() => {
+    if (reviewImageList.length > 0 && reviewData.text.length >= 35) {
+      setIsSubmitAvailable(true);
+    }
+  }, [reviewImageList, reviewData]);
 
   const handleImageUpload = async (e: React.ChangeEvent<HTMLInputElement>) => {
     if (e.target.files === null) return;
@@ -55,6 +69,7 @@ function Write() {
     tempImageList.splice(index, 1);
     setReviewImageList(tempImageList);
   };
+
   // 기존 대표 이미지와 교체
   const changeMainImage = (index: number) => {
     const newMainImage = reviewImageList[index];
@@ -63,6 +78,28 @@ function Write() {
     tempImageList.splice(index, 1, prevMainImage);
     tempImageList.splice(0, 1, newMainImage);
     setReviewImageList(tempImageList);
+  };
+
+  const handleTextChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+    let data = e.target.value;
+    if (data.length > 500) {
+      data = data.slice(0, 500);
+    }
+    const tempData: ReviewData = { ...reviewData };
+    tempData.text = data;
+    setReviewData(tempData);
+  };
+
+  const handleTagSubmit = (data: string) => {
+    const tempData: ReviewData = { ...reviewData };
+    tempData.tags.push(data);
+    setReviewData(tempData);
+  };
+
+  const handleTagDelete = (data: string) => {
+    const tempData: ReviewData = { ...reviewData };
+    tempData.tags = tempData.tags.filter((tag) => tag !== data);
+    setReviewData(tempData);
   };
 
   return (
@@ -78,6 +115,7 @@ function Write() {
         handleImageDelete={handleImageDelete}
         changeMainImage={changeMainImage}
       />
+      <ReviewText text={reviewData.text} handleTextChange={handleTextChange} />
     </>
   );
 }

--- a/src/pages/review/write.tsx
+++ b/src/pages/review/write.tsx
@@ -1,6 +1,7 @@
 import PreviewImageList from 'components/review/write/PreviewImageList';
 import PreviewImageMain from 'components/review/write/PreviewImageMain';
 import ReviewText from 'components/review/write/ReviewText';
+import TagList from 'components/review/write/TagList';
 import { useEffect, useState } from 'react';
 import { ReviewImage } from 'types/review';
 
@@ -116,6 +117,11 @@ function Write() {
         changeMainImage={changeMainImage}
       />
       <ReviewText text={reviewData.text} handleTextChange={handleTextChange} />
+      <TagList
+        tags={reviewData.tags}
+        handleTagSubmit={handleTagSubmit}
+        handleTagDelete={handleTagDelete}
+      />
     </>
   );
 }


### PR DESCRIPTION
## ✨ 구현 기능 명세
- 텍스트 최소 35자, 최대 500자 입력 가능
  - 500자 넘어가면 `slice(0, 500)`을 통해서 넘치는 글자는 버림
- 해시태그 최대 8자, 4개까지 추가 가능
  - 해시태그 클릭하면 태그 삭제, `enter`나 `,` 입력하면 태그 추가
- 필수값 입력 및 조건 만족시 작성완료 버튼 활성화

## 🎁 PR Point
- 텍스트 입력할 때마다 `useEffect`를 통해 조건을 만족하는지 확인하는데, 성능에 영향을 줄 수도 있을 것 같다.
- 아직 리뷰작성 페이지 합치기 전이라서 감안하고 봐주세용 ㅎㅁㅎ
- 생각보다 이미지 업로드 관련 함수가 길어서 이걸 분리해야 할지,,, 고민중

## 🕰 소요시간
- 약 2시간...?

## 😭 어려웠던 점
- `textarea` 커스텀이 생각보다 까다로웠다 ㅎㅎ,,,
- 요즘 바빠서 개발 하나도 못했는데 너무 미안하다 ㅠㅡㅠ 남은 기간 열심히 할게!
