### PR TITLE
[#99] [FEATURE] E#8-S#2 저장한 소품샵 페이지 필터 구현

### DIFF
--- a/src/features/shops/shopApi.ts
+++ b/src/features/shops/shopApi.ts
@@ -76,11 +76,12 @@ export const shopApi = createApi({
       }),
       transformResponse: (response: SodamResponse<ShopSubwayResponse>) => response.data,
     }),
-    getShopByBookmark: builder.query<SodamResponse<ShopResponse[]>, ShopBookmarkRequestType>({
+    getShopByBookmark: builder.query<ShopResponse[], ShopBookmarkRequestType>({
       query: ({ sort, offset, limit }) => ({
         url: `https://server.sodam.me/shop/bookmark?sort=${sort}&offset=${offset}&limit=${limit}`,
         method: 'GET',
       }),
+      transformResponse: (response: SodamResponse<ShopResponse[]>) => response.data,
     }),
     postBookmark: builder.mutation<SodamResponse<BookmarkResponseType>, BookmarkResquestType>({
       query: ({ shopId, isBookmarked }) => ({

--- a/src/pages/review/detail/[reviewId].tsx
+++ b/src/pages/review/detail/[reviewId].tsx
@@ -32,6 +32,27 @@ function Detail() {
     limit: 9,
   });
 
+  const filterProps = [
+    {
+      filterName: '좋아요 많은 순',
+      onClick: () => {
+        console.log('좋아요 많은 순');
+      },
+    },
+    {
+      filterName: '스크랩 많은 순',
+      onClick: () => {
+        console.log('스크랩 많은 순');
+      },
+    },
+    {
+      filterName: '최신 순',
+      onClick: () => {
+        console.log('최신 순');
+      },
+    },
+  ];
+
   const getFilteredReviewListData = () => {
     if (!reviewResponse) return [];
     const { data: reviewList } = reviewResponse;
@@ -47,7 +68,7 @@ function Detail() {
       <OtherReviewCardWrapper>
         <ReviewListHeader>
           <HeaderTitle>이 소품샵의 다른 리뷰</HeaderTitle>
-          <DropDownFilter pageType="detail" />
+          <DropDownFilter pageType="detail" filterProps={filterProps} />
         </ReviewListHeader>
         <ReviewListContent>
           {reviewResponse && <OtherReviewCard reviewListData={getFilteredReviewListData()} />}

--- a/src/pages/review/detail/[reviewId].tsx
+++ b/src/pages/review/detail/[reviewId].tsx
@@ -32,27 +32,6 @@ function Detail() {
     limit: 9,
   });
 
-  const filterProps = [
-    {
-      filterName: '좋아요 많은 순',
-      onClick: () => {
-        console.log('좋아요 많은 순');
-      },
-    },
-    {
-      filterName: '스크랩 많은 순',
-      onClick: () => {
-        console.log('스크랩 많은 순');
-      },
-    },
-    {
-      filterName: '최신 순',
-      onClick: () => {
-        console.log('최신 순');
-      },
-    },
-  ];
-
   const getFilteredReviewListData = () => {
     if (!reviewResponse) return [];
     const { data: reviewList } = reviewResponse;
@@ -68,7 +47,7 @@ function Detail() {
       <OtherReviewCardWrapper>
         <ReviewListHeader>
           <HeaderTitle>이 소품샵의 다른 리뷰</HeaderTitle>
-          <DropDownFilter pageType="detail" filterProps={filterProps} />
+          <DropDownFilter pageType="detail" />
         </ReviewListHeader>
         <ReviewListContent>
           {reviewResponse && <OtherReviewCard reviewListData={getFilteredReviewListData()} />}

--- a/src/pages/shop/collect.tsx
+++ b/src/pages/shop/collect.tsx
@@ -24,21 +24,15 @@ function Collect(props: CollectPrefetchProps) {
   const filterProps = [
     {
       filterName: '저장 많은 순',
-      onClick: () => {
-        updateList('save');
-      },
+      onClick: async () => updateList('save'),
     },
     {
       filterName: '리뷰 많은 순',
-      onClick: async () => {
-        updateList('review');
-      },
+      onClick: async () => updateList('review'),
     },
     {
       filterName: '최근 저장한 순',
-      onClick: async () => {
-        updateList('recent');
-      },
+      onClick: async () => updateList('recent'),
     },
   ];
 

--- a/src/pages/shop/collect.tsx
+++ b/src/pages/shop/collect.tsx
@@ -2,6 +2,7 @@ import { wrapper } from 'app/store';
 import DropDownFilter from 'components/common/DropDownFilter';
 import ShopCard from 'components/common/ShopCard';
 import { shopApi } from 'features/shops/shopApi';
+import { useState } from 'react';
 import styled from 'styled-components';
 import { theme } from 'styles/theme';
 import { ShopResponse } from 'types/shop';
@@ -10,17 +11,45 @@ interface CollectPrefetchProps {
   collectShopList: ShopResponse[];
 }
 
-function collect(props: CollectPrefetchProps) {
+function Collect(props: CollectPrefetchProps) {
   const { collectShopList } = props;
+  const [trigger] = shopApi.useLazyGetShopByBookmarkQuery();
+  const [currentList, setCurrentList] = useState<ShopResponse[] | undefined>(collectShopList);
+
+  const updateList = async (sortType: string) => {
+    const result = await trigger({ sort: sortType, offset: 1, limit: 12 });
+    setCurrentList(result.data);
+  };
+
+  const filterProps = [
+    {
+      filterName: '저장 많은 순',
+      onClick: () => {
+        updateList('save');
+      },
+    },
+    {
+      filterName: '리뷰 많은 순',
+      onClick: async () => {
+        updateList('review');
+      },
+    },
+    {
+      filterName: '최근 저장한 순',
+      onClick: async () => {
+        updateList('recent');
+      },
+    },
+  ];
 
   return (
     <StyledContainer>
       <h2>저장한 소품샵</h2>
       <StyledFilterWrapper>
-        <DropDownFilter pageType="collect" />
+        <DropDownFilter pageType="collect" filterProps={filterProps} />
       </StyledFilterWrapper>
       <StyledCardWrapper>
-        {collectShopList.map((shop) => (
+        {currentList?.map((shop) => (
           <ShopCard key={shop.shopId} cardData={shop} />
         ))}
       </StyledCardWrapper>
@@ -28,25 +57,17 @@ function collect(props: CollectPrefetchProps) {
   );
 }
 
-export default collect;
+export default Collect;
 
 export const getServerSideProps = wrapper.getServerSideProps((store) => async () => {
   const dispatch = store.dispatch;
   const collectShopResult = await dispatch(
     shopApi.endpoints.getShopByBookmark.initiate({ sort: 'save', offset: 1, limit: 12 }),
   );
-  let responseData: ShopResponse[] = [];
-
-  if (collectShopResult.isSuccess) {
-    const axiosResult = collectShopResult.data;
-    if (axiosResult.status === 200) {
-      responseData = axiosResult.data;
-    }
-  }
 
   return {
     props: {
-      collectShopList: responseData,
+      collectShopList: collectShopResult.data || [],
     },
   };
 });


### PR DESCRIPTION
<!-- PR의 제목은 "[#이슈번호] 이슈이름" 으로 작성해주시면 되겠습니다 -->

## ✨ 구현 기능 명세
+ 저장한 소품샵 페이지 필터를 구현하였습니다.
+ DropdownFilter와 FilterDiv에 필터 객체 배열 props를 전달 할 수 있도록 환경을 세팅 해 두었습니다.
```
const filterProps = [
    {
      filterName: '저장 많은 순',
      onClick: () => {
        updateList('save');
      },
    },
    {
      filterName: '리뷰 많은 순',
      onClick: async () => {
        updateList('review');
      },
    },
    {
      filterName: '최근 저장한 순',
      onClick: async () => {
        updateList('recent');
      },
    },
  ];
```
필터 객체 배열은 다음과 같이 생겼습니다. onClick 함수에 필터 변경 함수를 넘겨주시면 됩니다!

## 🎁 PR Point
고칠 부분 없는지 봐주세욧!

## 🕰 소요시간
1.5h

## 😭 어려웠던 점
없습니다!