### PR TITLE
[#104] [FEATURE] E#8-S#2 테마별소품샵 페이지 필터

### DIFF
--- a/src/features/shops/shopApi.ts
+++ b/src/features/shops/shopApi.ts
@@ -30,7 +30,7 @@ export const shopApi = createApi({
         },
       }),
     }),
-    getShopByTheme: builder.query<SodamResponse<ShopResponse[]>, ShopThemeRequestType>({
+    getShopByTheme: builder.query<ShopResponse[], ShopThemeRequestType>({
       query: ({ theme, sortType, offset, limit }) => ({
         url: 'https://server.sodam.me/shop',
         params: {
@@ -41,6 +41,7 @@ export const shopApi = createApi({
         },
         method: 'GET',
       }),
+      transformResponse: (response: SodamResponse<ShopResponse[]>) => response.data,
     }),
     getShopByShopId: builder.query<Shop, number>({
       query: (shopId) => ({


### PR DESCRIPTION
<!-- PR의 제목은 "[#이슈번호] 이슈이름" 으로 작성해주시면 되겠습니다 -->

## ✨ 구현 기능 명세

테마별 소품샵 페이지 필터를 구현했어요.

## 🎁 PR Point

`useLazyQuery` 를 사용하지 않고 각 카테고리별 sort된 결과를 미리 프리패치해놓았어요.
이후에 무한스크롤 구현 시 `useLazyQuery`를 사용해서 구현할 것 같아요

## 🕰 소요시간

1h

## 😭 어려웠던 점

없었슴다
