### PR TITLE
[#000] [EDIT] E#7-S-7 소품샵 상세 더미데이터 이미지 제거

### DIFF
--- a/src/components/ShopDetail/DetailImageGrid/index.tsx
+++ b/src/components/ShopDetail/DetailImageGrid/index.tsx
@@ -1,28 +1,19 @@
 import ImageDiv from 'components/common/ImageDiv';
+import shortid from 'shortid';
 import styled from 'styled-components';
 
 function DetailImageGrid({ imageList }: { imageList: string[] }) {
   return (
     <Container>
-      <ImageDiv className="detail-image" src={imageList[0]} layout="fill" alt="main-img" />
-      <ImageDiv
-        className="detail-image"
-        src="/assets/dummy/dummy-shop.png"
-        layout="fill"
-        alt="sub-img"
-      />
-      <ImageDiv
-        className="detail-image"
-        src="/assets/dummy/dummy-shop.png"
-        layout="fill"
-        alt="sub-img"
-      />
-      <ImageDiv
-        className="detail-image"
-        src="/assets/dummy/dummy-shop.png"
-        layout="fill"
-        alt="sub-img"
-      />
+      {imageList.map((imageSrc) => (
+        <ImageDiv
+          key={shortid.generate()}
+          className="detail-image"
+          src={imageSrc}
+          layout="fill"
+          alt="main-img"
+        />
+      ))}
     </Container>
   );
 }


### PR DESCRIPTION
<!-- PR의 제목은 "[#이슈번호] 이슈이름" 으로 작성해주시면 되겠습니다 -->

## ✨ 구현 기능 명세
소품샵 상세 페이지 더미데이터 이미지를 제거했습니다.

## 🎁 PR Point
혁진이가 자기가 수정 했다고 해놓고 반영 안돼서 물어보니까 까먹었다고 나보고 하라고 함ㅋㅋ

## 🕰 소요시간
1분

## 😭 어려웠던 점
없습니다!