### PR TITLE
[#144] [FEATURE] E#11-S#6 닉네임 중복확인 api 연결

### DIFF
--- a/src/components/Auth/SignupForm.tsx
+++ b/src/components/Auth/SignupForm.tsx
@@ -2,7 +2,7 @@ import PersonalInfoInput from 'components/common/PersonalInfoInput';
 import React, { useEffect } from 'react';
 import styled from 'styled-components';
 import { theme } from 'styles/theme';
-import { UserSignupRequest } from 'types/user';
+import { UserSignupRequest } from 'types/auth';
 
 interface SignupFormProps {
   signupInfo: UserSignupRequest;
@@ -13,8 +13,11 @@ interface SignupFormProps {
 function SignupForm(props: SignupFormProps) {
   const { signupInfo, handleOnChange, handleComplete } = props;
   const isPasswordEqual = signupInfo.password.value === signupInfo.passwordConfirm.value;
-
   const InfoList = Object.keys(signupInfo);
+  const isCompleteList = {
+    nickname: signupInfo.nickname.isComplete,
+    emailConfirm: signupInfo.emailConfirm.isComplete,
+  };
 
   useEffect(() => {
     if (signupInfo.passwordConfirm.value && isPasswordEqual)
@@ -37,6 +40,7 @@ function SignupForm(props: SignupFormProps) {
               handleComplete={handleComplete}
               passwordError={signupInfo.passwordConfirm.value && !isPasswordEqual}
               order={idx}
+              isCompleteList={isCompleteList}
             />
           );
         }

--- a/src/components/Auth/SignupOption.tsx
+++ b/src/components/Auth/SignupOption.tsx
@@ -1,13 +1,29 @@
+import { usePostNicknameMutation } from 'features/auth/authApi';
 import React from 'react';
 import styled from 'styled-components';
 import { theme } from 'styles/theme';
+import { UserSignupRequest } from 'types/auth';
 
 interface SignupOptionProps {
   type: string;
   error: boolean;
+  value: string;
+  nicknameComplete: boolean;
+  handleConfirm: (type: keyof UserSignupRequest, value: boolean) => void;
 }
 function SignupOption(props: SignupOptionProps) {
-  const { type, error } = props;
+  const { type, error, value, handleConfirm, nicknameComplete } = props;
+  const [nickname] = usePostNicknameMutation();
+  const handleClick = async () => {
+    if (value) {
+      try {
+        const { uniqueNickname } = await nickname({ nickname: value }).unwrap();
+        handleConfirm('nickname', uniqueNickname);
+      } catch (error) {
+        console.log(error);
+      }
+    }
+  };
 
   const getSignOption = (type: string) => {
     switch (type) {
@@ -19,7 +35,12 @@ function SignupOption(props: SignupOptionProps) {
         );
       case 'nickname':
         return (
-          <StyledBtn tabIndex={-1} inputType={type}>
+          <StyledBtn
+            onClick={handleClick}
+            tabIndex={-1}
+            inputType={type}
+            disabled={error || nicknameComplete}
+          >
             중복확인
           </StyledBtn>
         );

--- a/src/components/common/PersonalInfoInput.tsx
+++ b/src/components/common/PersonalInfoInput.tsx
@@ -42,12 +42,11 @@ function PersonalInfoInput(props: PersonalInfoInputProps) {
       return <StyledNoticeErr>{inputInfo.notice}</StyledNoticeErr>;
     }
 
-    if (type === 'nickname') {
-      if (isConfirm && isCompleteList.nickname) {
+    if (type === 'nickname' && isConfirm) {
+      if (isCompleteList.nickname) {
         return <StyledNoticeErr>{inputInfo.completeNotice}</StyledNoticeErr>;
-      } else if (isConfirm && !isCompleteList.nickname) {
-        return <StyledNoticeErr>{inputInfo.unCompleteNotice}</StyledNoticeErr>;
       }
+      return <StyledNoticeErr>{inputInfo.unCompleteNotice}</StyledNoticeErr>;
     }
 
     return <StyledNoticeErr />;

--- a/src/components/review/ReviewDetailCard.tsx
+++ b/src/components/review/ReviewDetailCard.tsx
@@ -87,7 +87,7 @@ function ReviewDetailCard(props: ReviewDetailCardProps) {
             </ScrapReview>
           </IconContainer>
         </ReviewDetailCardHeader>
-        <ImageSlider imageList={image} />
+        <ImageSlider imageList={image || []} />
         <ReviewTextInfo>
           <ReviewProductInfo>
             {item.map((itemElement) => (

--- a/src/constants/joinInfoList.ts
+++ b/src/constants/joinInfoList.ts
@@ -10,15 +10,15 @@ export const joinInfoList: ObjectsType = {
     type: 'text',
     placeholder: '리뷰 작성 시 사용할 닉네임을 적어주세요',
     notice: '입력 형식에 맞지 않습니다',
-    btnNotice: '이미 가입된 이메일입니다.',
+    unCompleteNotice: '이미 사용중인 닉네임입니다',
+    completeNotice: '사용 가능한 닉네임입니다',
   },
   email: {
     title: 'ID (이메일)',
     type: 'email',
     placeholder: 'example@naver.com',
     notice: '입력 형식에 맞지 않습니다',
-    btnNotice: '이미 사용중인 닉네임입니다',
-    completeNotice: '사용 가능한 닉네임입니다',
+    unCompleteNotice: '이미 가입된 이메일입니다.',
   },
   emailConfirm: {
     title: 'ID (이메일) 인증번호',

--- a/src/features/auth/authApi.ts
+++ b/src/features/auth/authApi.ts
@@ -1,0 +1,25 @@
+import { createApi } from '@reduxjs/toolkit/query/react';
+import { axiosBaseQuery } from 'libs/api';
+import { SodamResponse } from 'types/api';
+import { nicknameRequestType, nicknameResponseType } from 'types/auth';
+
+export const authApi = createApi({
+  reducerPath: 'authApi',
+  baseQuery: axiosBaseQuery(),
+  refetchOnFocus: true,
+  endpoints: (builder) => ({
+    // builder.query<T, U>() --> T는 쿼리의 반환값 타입, U는 쿼리 파라미터의 타입.
+    postNickname: builder.mutation<nicknameResponseType, nicknameRequestType>({
+      query: ({ nickname }) => ({
+        url: 'https://server.sodam.me/auth/signup/nickname',
+        method: 'POST',
+        data: {
+          nickname,
+        },
+      }),
+      transformResponse: (response: SodamResponse<nicknameResponseType>) => response.data,
+    }),
+  }),
+});
+
+export const { usePostNicknameMutation } = authApi;

--- a/src/hooks/useInput.ts
+++ b/src/hooks/useInput.ts
@@ -4,7 +4,6 @@ import { UserSignupRequest } from 'types/auth';
 function useInput(
   inputType: keyof UserSignupRequest,
   handleOnChange: (type: keyof UserSignupRequest, value: string) => void,
-  // isConfirm: boolean,
 ) {
   const [value, setValue] = useState('');
   const [isError, setIsError] = useState(true);

--- a/src/hooks/useInput.ts
+++ b/src/hooks/useInput.ts
@@ -1,9 +1,10 @@
 import { ChangeEvent, useState } from 'react';
-import { UserSignupRequest } from 'types/user';
+import { UserSignupRequest } from 'types/auth';
 
 function useInput(
   inputType: keyof UserSignupRequest,
   handleOnChange: (type: keyof UserSignupRequest, value: string) => void,
+  // isConfirm: boolean,
 ) {
   const [value, setValue] = useState('');
   const [isError, setIsError] = useState(true);
@@ -21,6 +22,7 @@ function useInput(
 
   const onChange = (e: ChangeEvent<HTMLInputElement>) => {
     setValue(e.target.value);
+
     if (handleOnChange) {
       handleOnChange(inputType, e.target.value);
     }

--- a/src/pages/auth/join.tsx
+++ b/src/pages/auth/join.tsx
@@ -4,7 +4,7 @@ import ThemeSelector from 'components/Auth/ThemeSelector';
 import { useCallback, useEffect, useState } from 'react';
 import styled from 'styled-components';
 import { theme } from 'styles/theme';
-import { UserSignupRequest } from 'types/user';
+import { UserSignupRequest } from 'types/auth';
 
 function Join() {
   const [signupInfo, setSignupInfo] = useState<UserSignupRequest>({

--- a/src/types/auth.ts
+++ b/src/types/auth.ts
@@ -17,3 +17,11 @@ export type UserSignupRequest = Record<
     isComplete: boolean;
   }
 > & { themePreference: { value: string[]; isComplete: boolean } };
+
+export interface nicknameResponseType {
+  uniqueNickname: boolean;
+}
+
+export interface nicknameRequestType {
+  nickname: string;
+}


### PR DESCRIPTION
<!-- PR의 제목은 "[#이슈번호] 이슈이름" 으로 작성해주시면 되겠습니다 -->

* Closes #144 

## ✨ 구현 기능 명세
닉네임 중복 확인 api를 연결했습니다.

## 🎁 PR Point
와... 진짜 닉네임 서버는 금방 붙였는데 붙이고나서 뭐 중복일땐 이미있다고 안내하고 사용가능할땐 사용가능하다고 안내해야되고 버튼도 활성화 됐다가 비활성화 됐다가 아주 그냥 조건이 너무 많아서 미치는줄 알았습니다..... 그래서 코드가 원래도 🐶같았는데 더더욱 🐶같아졌어요 ㅋㅋ 어쩌죠~

## 🕰 소요시간
음..모르겠어요

## 😭 어려웠던 점
그냥 모든 로직 하나하나 다...ㅋㅎㅋㅎ 회원가입 트라우마 생길듯
