### PR TITLE
[#170][FEATURE] E#13-S#6~9 나머지 페이지 모바일 반응형

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -6,6 +6,7 @@ module.exports = {
   reactStrictMode: true,
   images: {
     domains: [
+      'sodam-bucket-2.s3.ap-northeast-2.amazonaws.com',
       'sodam-bucket.s3.ap-northeast-2.amazonaws.com',
       'search.pstatic.net',
       'source.unsplash.com',

--- a/src/components/ShopDetail/DetailShopAddress/index.tsx
+++ b/src/components/ShopDetail/DetailShopAddress/index.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import styled from 'styled-components';
 import { applyMediaQuery } from 'styles/mediaQuery';
 import { getBackgroundImageCss } from 'styles/mixin';
@@ -28,6 +28,11 @@ function DetailShopAddress({ roadAddress, landAddress }: AddressProps) {
   };
 
   const copyAddressToClipboard = async () => await navigator.clipboard.writeText(currentAddress);
+
+  useEffect(() => {
+    setCurrentAddress(roadAddress);
+    setCurrentAddressType(ROAD);
+  }, [roadAddress]);
 
   return (
     <Container>
@@ -124,9 +129,8 @@ const Address = styled.span`
     word-break: keep-all;
     font-size: 0.6rem;
     line-height: 1.5rem;
-    /* width: fit-content; */
     transform: scale(0.6);
-    margin: 0 -4rem;
+    margin: 0 -3.5rem;
   }
 `;
 

--- a/src/components/ThemeSelector/ThemeElement.tsx
+++ b/src/components/ThemeSelector/ThemeElement.tsx
@@ -81,6 +81,9 @@ const StyledRoot = styled.div<Pick<StyledELProps, 'isActive'>>`
     ${applyMediaQuery('desktop')} {
       margin-top: ${({ isActive }) => (isActive ? '-3.3rem' : '1.3rem')};
     }
+    ${applyMediaQuery('tablet')} {
+      margin-top: ${({ isActive }) => (isActive ? '-2.5rem' : '0.7rem')};
+    }
     ${applyMediaQuery('mobile')} {
       margin-top: ${({ isActive }) => (isActive ? '-1.7rem' : '0.3rem')};
     }

--- a/src/components/ThemeSelector/index.tsx
+++ b/src/components/ThemeSelector/index.tsx
@@ -59,6 +59,14 @@ const StyledRoot = styled.div`
 
     gap: 3.8rem;
   }
+  ${applyMediaQuery('tablet')} {
+    & > h4 {
+      font-size: 2rem;
+      line-height: 2.9rem;
+    }
+
+    gap: 2.7rem;
+  }
   ${applyMediaQuery('mobile')} {
     & > h4 {
       font-size: 1.4rem;

--- a/src/components/common/DropDownFilter.tsx
+++ b/src/components/common/DropDownFilter.tsx
@@ -68,7 +68,7 @@ const StyledRoot = styled.div`
     position: relative;
     width: 1.4rem;
     height: 1rem;
-    ${applyMediaQuery('mobile')} {
+    ${applyMediaQuery('mobile', 'tablet')} {
       width: 1.1rem;
       height: 0.8rem;
     }
@@ -98,7 +98,7 @@ const StyledWrapper = styled.div`
       transform: scale(0.85);
     }
   }
-  ${applyMediaQuery('mobile')} {
+  ${applyMediaQuery('mobile', 'tablet')} {
     gap: 0.4rem;
     & > span {
       font-size: 0.9rem;

--- a/src/components/common/DropDownFilter.tsx
+++ b/src/components/common/DropDownFilter.tsx
@@ -1,11 +1,11 @@
 import { dropDownFilterList } from 'constants/dropdownOptionList';
-import Image from 'next/image';
 import { useState } from 'react';
 import styled from 'styled-components';
 import { applyMediaQuery } from 'styles/mediaQuery';
 import { theme } from 'styles/theme';
 
 import FilterDiv from './FilterDiv';
+import ImageDiv from './ImageDiv';
 
 interface StyledDDFProps {
   pageType: 'detail' | 'theme' | 'collect';
@@ -47,7 +47,12 @@ function DropDownFilter(props: StyledDDFProps) {
       )}
       <StyledWrapper onClick={toggle}>
         <span>{selected}</span>
-        <Image src={'/assets/ic_dropdown.svg'} width={14} height={10} alt="dropdown" />
+        <ImageDiv
+          className="dropdown-icon"
+          src={'/assets/ic_dropdown.svg'}
+          layout="fill"
+          alt="dropdown"
+        />
       </StyledWrapper>
     </StyledRoot>
   );
@@ -59,6 +64,15 @@ const StyledRoot = styled.div`
   display: flex;
   position: relative;
   align-items: flex-end;
+  .dropdown-icon {
+    position: relative;
+    width: 1.4rem;
+    height: 1rem;
+    ${applyMediaQuery('mobile')} {
+      width: 1.1rem;
+      height: 0.8rem;
+    }
+  }
 `;
 const StyledWrapper = styled.div`
   display: flex;
@@ -85,6 +99,7 @@ const StyledWrapper = styled.div`
     }
   }
   ${applyMediaQuery('mobile')} {
+    gap: 0.4rem;
     & > span {
       font-size: 0.9rem;
       line-height: 1.3rem;

--- a/src/components/common/EmptyContent.tsx
+++ b/src/components/common/EmptyContent.tsx
@@ -43,10 +43,15 @@ const StyledContainer = styled.div`
     position: relative;
     width: 28.2rem;
     height: 28.1rem;
-    ${applyMediaQuery('desktop')} {
+    ${applyMediaQuery('desktop', 'tablet')} {
       width: 18.7rem;
       height: 18.7rem;
       margin-top: 3.2rem;
+    }
+    ${applyMediaQuery('mobile')} {
+      width: 12.4rem;
+      height: 12.3rem;
+      margin-top: 10rem;
     }
   }
 `;
@@ -55,9 +60,13 @@ const Header = styled.h2`
   line-height: 4.3rem;
   font-weight: 700;
   color: ${({ theme }) => theme.colors.black2};
-  ${applyMediaQuery('desktop')} {
+  ${applyMediaQuery('desktop', 'tablet')} {
     font-size: 2.6rem;
     line-height: 3.8rem;
+  }
+  ${applyMediaQuery('mobile')} {
+    font-size: 1.4rem;
+    line-height: 2rem;
   }
 `;
 const ContentWrapper = styled.div`
@@ -75,10 +84,16 @@ const Label = styled.p`
   line-height: 3.4rem;
   margin-bottom: 0.8rem;
   color: ${({ theme }) => theme.colors.purpleText};
-  ${applyMediaQuery('desktop')} {
+  ${applyMediaQuery('desktop', 'tablet')} {
     font-size: 2rem;
     line-height: 2.9rem;
     margin-top: 0.6rem;
+    margin-bottom: 0.4rem;
+  }
+  ${applyMediaQuery('mobile')} {
+    font-size: 1.4rem;
+    line-height: 2rem;
+    margin-top: 0.5rem;
     margin-bottom: 0.4rem;
   }
 `;
@@ -94,6 +109,11 @@ const SubLabel = styled.p`
     line-height: 2rem;
     margin-bottom: 3rem;
   }
+  ${applyMediaQuery('mobile')} {
+    font-size: 1.1rem;
+    line-height: 1.6rem;
+    margin-bottom: 2.2rem;
+  }
 `;
 const Button = styled.button`
   font-size: 1.6rem;
@@ -108,6 +128,11 @@ const Button = styled.button`
     font-size: 1.2rem;
     width: 25.5rem;
     height: 3.3rem;
+  }
+  ${applyMediaQuery('mobile')} {
+    font-size: 1rem;
+    width: 16.8rem;
+    height: 2.6rem;
   }
 `;
 

--- a/src/components/common/EmptyContent.tsx
+++ b/src/components/common/EmptyContent.tsx
@@ -48,6 +48,9 @@ const StyledContainer = styled.div`
       height: 18.7rem;
       margin-top: 3.2rem;
     }
+    ${applyMediaQuery('tablet')} {
+      margin-top: 10rem;
+    }
     ${applyMediaQuery('mobile')} {
       width: 12.4rem;
       height: 12.3rem;
@@ -60,9 +63,13 @@ const Header = styled.h2`
   line-height: 4.3rem;
   font-weight: 700;
   color: ${({ theme }) => theme.colors.black2};
-  ${applyMediaQuery('desktop', 'tablet')} {
+  ${applyMediaQuery('desktop')} {
     font-size: 2.6rem;
     line-height: 3.8rem;
+  }
+  ${applyMediaQuery('tablet')} {
+    font-size: 2rem;
+    line-height: 2.9rem;
   }
   ${applyMediaQuery('mobile')} {
     font-size: 1.4rem;
@@ -104,7 +111,7 @@ const SubLabel = styled.p`
   line-height: 2.6rem;
   margin-bottom: 4rem;
   color: ${({ theme }) => theme.colors.gray1};
-  ${applyMediaQuery('desktop')} {
+  ${applyMediaQuery('desktop', 'tablet')} {
     font-size: 1.4rem;
     line-height: 2rem;
     margin-bottom: 3rem;
@@ -124,7 +131,7 @@ const Button = styled.button`
   color: white;
   border: 0;
   border-radius: 5px;
-  ${applyMediaQuery('desktop')} {
+  ${applyMediaQuery('desktop', 'tablet')} {
     font-size: 1.2rem;
     width: 25.5rem;
     height: 3.3rem;

--- a/src/components/common/FilterDiv.tsx
+++ b/src/components/common/FilterDiv.tsx
@@ -72,7 +72,7 @@ const StyledUl = styled.ul`
     cursor: pointer;
   }
 
-  ${applyMediaQuery('desktop', 'tablet')} {
+  ${applyMediaQuery('desktop', 'tablet', 'mobile')} {
     width: 8.3rem;
     padding: 1.3rem 1rem;
     gap: 0.5rem;

--- a/src/components/common/Footer.tsx
+++ b/src/components/common/Footer.tsx
@@ -60,9 +60,13 @@ const FooterWrapper = styled.div`
   display: flex;
   justify-content: space-between;
   padding: 5.4rem 0;
+  ${applyMediaQuery('tablet')} {
+    padding: 3.8rem 0;
+    gap: 2rem;
+  }
   ${applyMediaQuery('mobile')} {
-    padding: 1.8rem 0;
-    gap: 3.7rem;
+    padding: 2.5rem 0;
+    gap: 1.7rem;
   }
   color: ${({ theme }) => theme.colors.black2};
 `;
@@ -71,6 +75,11 @@ const Logo = styled.div`
   flex: 1;
   ${applyMediaQuery('desktop')} {
     transform: scale(0.75);
+  }
+  ${applyMediaQuery('tablet')} {
+    transform: scale(0.6);
+    transform-origin: top left;
+    width: 11rem;
   }
 `;
 
@@ -83,6 +92,9 @@ const LeftFooter = styled.div`
   justify-content: space-between;
   margin-bottom: 1.5rem;
   gap: 2.4rem;
+  ${applyMediaQuery('tablet')} {
+    gap: 1rem;
+  }
 `;
 
 const MobileFontStyle = css`
@@ -95,8 +107,11 @@ const ContactTitle = styled.div`
   font-weight: 600;
   font-size: 1.4rem;
 
+  ${applyMediaQuery('tablet')} {
+    font-size: 1.3rem;
+  }
   ${applyMediaQuery('mobile')} {
-    width: 2.5rem;
+    width: 2.8rem;
     ${MobileFontStyle}
   }
 `;
@@ -112,6 +127,9 @@ const ContactContent = styled.li`
     color: inherit;
   }
 
+  ${applyMediaQuery('tablet')} {
+    font-size: 1.3rem;
+  }
   ${applyMediaQuery('mobile')} {
     ${MobileFontStyle}
   }
@@ -126,8 +144,12 @@ const RightFooterWrapper = styled.div`
   flex-direction: column;
   gap: 1.6rem;
 
+  ${applyMediaQuery('tablet')} {
+    font-size: 1.3rem;
+  }
   ${applyMediaQuery('mobile')} {
     ${MobileFontStyle}
+    gap: 1rem;
   }
 `;
 
@@ -139,6 +161,12 @@ const RightFooter = styled.li`
   & > a {
     text-decoration: none;
     color: inherit;
+  }
+
+  ${applyMediaQuery('mobile')} {
+    & > a {
+      line-height: 1rem;
+    }
   }
 `;
 

--- a/src/components/common/MoreFilter.tsx
+++ b/src/components/common/MoreFilter.tsx
@@ -75,6 +75,11 @@ const StyledWrapper = styled.div`
       font-size: 1.6rem;
     }
   }
+  ${applyMediaQuery('tablet')} {
+    & > span {
+      font-size: 1.3rem;
+    }
+  }
   ${applyMediaQuery('mobile')} {
     & > span {
       font-size: 0.9rem;
@@ -106,6 +111,9 @@ const StyledLi = styled.li<StyledMFProps>`
   color: ${({ isActive }) => (isActive ? theme.colors.purpleText : theme.colors.gray1)};
   cursor: pointer;
 
+  ${applyMediaQuery('tablet')} {
+    font-size: 1.3rem;
+  }
   ${applyMediaQuery('mobile')} {
     font-size: 0.9rem;
     line-height: 1.3rem;

--- a/src/components/common/Navbar/GlobalNav/Mobile.tsx
+++ b/src/components/common/Navbar/GlobalNav/Mobile.tsx
@@ -1,3 +1,4 @@
+import ImageDiv from 'components/common/ImageDiv';
 import Image from 'next/image';
 import Link from 'next/link';
 import styled from 'styled-components';
@@ -21,7 +22,16 @@ function GlobalNavMobile(props: NavProps) {
           {isLogin ? (
             <Link href="/mypage" passHref>
               <StyledImage>
-                {userImage && <Image src={userImage} layout="fill" alt="profile" />}
+                {userImage ? (
+                  <Image src={userImage} layout="fill" alt="profile" />
+                ) : (
+                  <ImageDiv
+                    className="profile-icon"
+                    src={'/assets/profile.svg'}
+                    layout="fill"
+                    alt="profile"
+                  />
+                )}
               </StyledImage>
             </Link>
           ) : (
@@ -67,6 +77,11 @@ const NavTopRightWrapper = styled.div`
   display: flex;
   align-items: center;
   gap: 1.5rem;
+  .profile-icon {
+    position: relative;
+    width: 2rem;
+    height: 2rem;
+  }
 `;
 
 const StyledImage = styled.div`

--- a/src/components/common/Navbar/LocalNav.tsx
+++ b/src/components/common/Navbar/LocalNav.tsx
@@ -42,7 +42,7 @@ const LocalNavbarWrapper = styled.div`
   ${applyMediaQuery('desktop')} {
     height: 4.2rem;
   }
-  ${applyMediaQuery('mobile')} {
+  ${applyMediaQuery('mobile', 'tablet')} {
     height: 3.6rem;
   }
 `;
@@ -66,12 +66,12 @@ const LocalNavbar = styled.div`
   font-size: 1.6rem;
   color: ${({ theme }) => theme.colors.gray1};
 
-  ${applyMediaQuery('desktop', 'tablet')} {
+  ${applyMediaQuery('desktop')} {
     font-size: 1.1rem;
     line-height: 1.6rem;
     height: 4.2rem;
   }
-  ${applyMediaQuery('mobile')} {
+  ${applyMediaQuery('mobile', 'tablet')} {
     font-size: 1rem;
     line-height: 1.4rem;
     height: 3.6rem;
@@ -85,13 +85,13 @@ const LocalNavbar = styled.div`
 
   &::after {
     ${NavLineStyle}
-    ${applyMediaQuery('mobile')} {
+    ${applyMediaQuery('mobile', 'tablet')} {
       top: calc(5.9rem + 4.8rem + 3.6rem);
     }
   }
   &::before {
     ${NavLineStyle}
-    ${applyMediaQuery('mobile')} {
+    ${applyMediaQuery('mobile', 'tablet')} {
       top: calc(5.9rem + 4.8rem);
     }
   }
@@ -113,7 +113,10 @@ const ReviewMenu = styled.a<{ isActive: boolean }>`
     cursor: pointer;
   }
 
-  ${applyMediaQuery('mobile')} {
+  ${applyMediaQuery('tablet')} {
+    margin-right: 4.5rem;
+  }
+  ${applyMediaQuery('mobile', 'tablet')} {
     margin-top: -0.7rem;
   }
 `;

--- a/src/components/common/Navbar/LocalNav.tsx
+++ b/src/components/common/Navbar/LocalNav.tsx
@@ -112,5 +112,9 @@ const ReviewMenu = styled.a<{ isActive: boolean }>`
   &:hover {
     cursor: pointer;
   }
+
+  ${applyMediaQuery('mobile')} {
+    margin-top: -0.7rem;
+  }
 `;
 export default LocalNav;

--- a/src/components/common/PageNaviagator.tsx
+++ b/src/components/common/PageNaviagator.tsx
@@ -61,11 +61,17 @@ const Container = styled.nav`
   ${applyMediaQuery('desktop')} {
     transform: scale(0.67);
   }
+  ${applyMediaQuery('mobile', 'tablet')} {
+    width: 31.2rem;
+  }
 `;
 
 const PageList = styled.ol`
   display: flex;
   gap: 8rem;
+  ${applyMediaQuery('mobile', 'tablet')} {
+    gap: 2.5rem;
+  }
 `;
 
 const Page = styled.li<{ isCurrent: boolean }>`
@@ -75,14 +81,23 @@ const Page = styled.li<{ isCurrent: boolean }>`
   font-weight: 500;
   font-size: 2rem;
   line-height: 2.9rem;
+  ${applyMediaQuery('mobile', 'tablet')} {
+    font-size: 1.2rem;
+  }
 `;
 
 const LeftBtn = styled(LeftArrow)`
   ${hoverPointer}
+  ${applyMediaQuery('mobile', 'tablet')} {
+    transform: scale(0.5);
+  }
 `;
 
 const RightBtn = styled(RightArrow)`
   ${hoverPointer}
+  ${applyMediaQuery('mobile', 'tablet')} {
+    transform: scale(0.5);
+  }
 `;
 
 export default PageNaviagator;

--- a/src/components/common/WriteReviewLink.tsx
+++ b/src/components/common/WriteReviewLink.tsx
@@ -48,7 +48,7 @@ const StyledWriteLink = styled.a`
     font-family: 'Noto Sans KR';
   }
 
-  ${applyMediaQuery('mobile')} {
+  ${applyMediaQuery('mobile', 'tablet')} {
     font-size: 0.8rem;
     line-height: 1.2rem;
     font-family: 'Noto Sans KR';
@@ -67,7 +67,7 @@ const WriteIcon = styled(writeIC)`
   margin-left: 0.8rem;
   align-self: center;
 
-  ${applyMediaQuery('mobile')} {
+  ${applyMediaQuery('mobile', 'tablet')} {
     order: -1;
     transform: scale(0.5) translateY(1px);
     margin: 0;

--- a/src/components/review/ImageCard.tsx
+++ b/src/components/review/ImageCard.tsx
@@ -34,6 +34,10 @@ const StyledRoot = styled.div`
     width: 5rem;
     height: 5rem;
   }
+  ${applyMediaQuery('mobile')} {
+    width: 4.2rem;
+    height: 4.2rem;
+  }
 `;
 
 export default ImageCard;

--- a/src/components/review/ImageSlider.tsx
+++ b/src/components/review/ImageSlider.tsx
@@ -1,5 +1,6 @@
 import 'swiper/swiper.min.css';
 
+import useMedia from 'hooks/useMedia';
 import Image from 'next/image';
 import React, { useMemo, useState } from 'react';
 import shortId from 'shortid';
@@ -20,6 +21,8 @@ function ImageSlider(props: ImageSliderProps) {
   const [currentIndex, setCurrentIndex] = useState(0);
   const [slideImageList, setSlideImageList] = useState(imageList.slice(1));
 
+  const { isMobile } = useMedia();
+
   const emptyCardCount: number = 7 - imageList.length;
   const emptyCardList: string[] | null =
     emptyCardCount > 0 ? new Array(emptyCardCount).fill('') : null; // 빈 카드 내용은 '' 로 채움
@@ -28,7 +31,7 @@ function ImageSlider(props: ImageSliderProps) {
 
   const settings = useMemo<Swiper>(
     () => ({
-      spaceBetween: 10, // px
+      spaceBetween: isMobile ? 5 : 10, // px
       navigation: {
         prevEl: '.button__prev', // 이전 버튼
         nextEl: '.button__next', // 다음 버튼
@@ -96,6 +99,10 @@ const ImageWrapper = styled.div`
     width: 52.6rem;
     height: 27rem;
   }
+  ${applyMediaQuery('mobile')} {
+    width: 31.2rem;
+    height: 22.1rem;
+  }
 `;
 
 const StyledRoot = styled.div`
@@ -131,7 +138,7 @@ const StyledRoot = styled.div`
       z-index: 2;
     }
   }
-  ${applyMediaQuery('desktop', 'tablet')} {
+  ${applyMediaQuery('desktop', 'tablet', 'mobile')} {
     .swiper-container {
       width: 33.5rem;
     }
@@ -148,6 +155,15 @@ const StyledRoot = styled.div`
       margin-top: 1.2rem;
     }
   }
+  ${applyMediaQuery('mobile')} {
+    .swiper-container {
+      width: 28rem;
+    }
+    .button__prev,
+    .button__next {
+      margin-top: 0.9rem;
+    }
+  }
 `;
 const StyledButton = styled.button`
   background: none;
@@ -159,6 +175,9 @@ const StyledSwiper = styled.div`
   margin-top: 3.2rem;
   ${applyMediaQuery('desktop', 'tablet')} {
     margin-top: 2rem;
+  }
+  ${applyMediaQuery('mobile')} {
+    margin-top: 1.2rem;
   }
 `;
 

--- a/src/components/review/OtherReview/Container/index.tsx
+++ b/src/components/review/OtherReview/Container/index.tsx
@@ -16,8 +16,22 @@ const ReviewList = styled.div`
   grid-template-columns: repeat(2, 1fr);
   column-gap: 1.6rem;
   row-gap: 2.4rem;
-  ${applyMediaQuery('desktop', 'tablet')} {
+  ${applyMediaQuery('desktop')} {
     gap: 1.6rem 1rem;
+  }
+  ${applyMediaQuery('tablet')} {
+    gap: 1rem 0.2rem;
+    & > div {
+      transform: scale(0.96);
+      transform-origin: top left;
+    }
+  }
+  ${applyMediaQuery('mobile')} {
+    gap: 1.2rem 0.7rem;
+    & > div {
+      transform: scale(0.99);
+      transform-origin: top left;
+    }
   }
 `;
 

--- a/src/components/review/ReviewDetailCard.tsx
+++ b/src/components/review/ReviewDetailCard.tsx
@@ -58,7 +58,7 @@ function ReviewDetailCard(props: ReviewDetailCardProps) {
     postApiFunc({ reviewId, isLiked: !isClicked, isScraped: !isClicked });
   };
 
-  const { isDesktop, isTablet } = useMedia();
+  const { isDesktop, isTablet, isMobile } = useMedia();
 
   return (
     <StyledReviewDetailCardContainer>
@@ -84,8 +84,8 @@ function ReviewDetailCard(props: ReviewDetailCardProps) {
             <LikeReview>
               <IcLikeReview
                 fill={isLikeClicked ? theme.colors.purpleMain : 'white'}
-                width={isDesktop || isTablet ? 19 : 29}
-                height={isDesktop || isTablet ? 17 : 26}
+                width={isDesktop || isTablet ? 19 : isMobile ? 16 : 29}
+                height={isDesktop || isTablet ? 17 : isMobile ? 14 : 26}
                 onClick={() => getOnClickHandlerByType('like')}
               />
               <p>{likedCount}</p>
@@ -93,8 +93,8 @@ function ReviewDetailCard(props: ReviewDetailCardProps) {
             <ScrapReview>
               <IcScrapReview
                 fill={isScrapClicked ? theme.colors.purpleMain : 'white'}
-                width={isDesktop || isTablet ? 15 : 22}
-                height={isDesktop || isTablet ? 17 : 26}
+                width={isDesktop || isTablet ? 15 : isMobile ? 12 : 22}
+                height={isDesktop || isTablet ? 17 : isMobile ? 14 : 26}
                 onClick={() => getOnClickHandlerByType('scrap')}
               />
               <p>{scrapedCount}</p>
@@ -131,6 +131,9 @@ const Header = styled.header`
   ${applyMediaQuery('desktop', 'tablet')} {
     margin-bottom: 2.8rem;
   }
+  ${applyMediaQuery('mobile')} {
+    margin-bottom: 1.3rem;
+  }
 `;
 
 const ShopName = styled.h2`
@@ -142,6 +145,10 @@ const ShopName = styled.h2`
     font-size: 2.6rem;
     margin-bottom: 0.4rem;
   }
+  ${applyMediaQuery('mobile')} {
+    font-size: 1.4rem;
+    margin-bottom: 0.5rem;
+  }
 `;
 
 const ShopInfo = styled.h3`
@@ -151,6 +158,10 @@ const ShopInfo = styled.h3`
   ${applyMediaQuery('desktop', 'tablet')} {
     font-size: 1.4rem;
     line-height: 2rem;
+  }
+  ${applyMediaQuery('mobile')} {
+    font-size: 1rem;
+    line-height: 1.4rem;
   }
 `;
 
@@ -162,6 +173,9 @@ const ReviewDetailCardContent = styled.div`
   margin-bottom: 5.6rem;
   ${applyMediaQuery('desktop', 'tablet')} {
     margin-bottom: 4rem;
+  }
+  ${applyMediaQuery('mobile')} {
+    margin-bottom: 3.5rem;
   }
 `;
 const ReviewDetailCardHeader = styled.div`
@@ -190,11 +204,19 @@ const ReviewDetailCardHeader = styled.div`
       height: 3.2rem;
     }
   }
+  ${applyMediaQuery('mobile')} {
+    margin: 0;
+    margin: 1rem 1.3rem;
+    .profile-image {
+      width: 2.7rem;
+      height: 2.7rem;
+    }
+  }
 `;
 
 const ReviewInfo = styled.div`
   margin-left: 1.6rem;
-  ${applyMediaQuery('desktop', 'tablet')} {
+  ${applyMediaQuery('desktop', 'tablet', 'mobile')} {
     margin-left: 1.1rem;
   }
 `;
@@ -210,6 +232,11 @@ const ReviewWriter = styled.p`
     line-height: 1.6rem;
     margin-bottom: 0.2rem;
   }
+  ${applyMediaQuery('mobile')} {
+    font-size: 1rem;
+    line-height: 1.3rem;
+    margin-bottom: 0.2rem;
+  }
 `;
 
 const ReviewWriteDate = styled.p`
@@ -221,6 +248,12 @@ const ReviewWriteDate = styled.p`
     font-size: 1rem;
     line-height: 1rem;
   }
+  ${applyMediaQuery('mobile')} {
+    font-size: 1rem;
+    transform: scale(0.7);
+    height: 1rem;
+    transform-origin: top left;
+  }
 `;
 
 const IconContainer = styled.div`
@@ -229,6 +262,11 @@ const IconContainer = styled.div`
   color: ${({ theme }) => theme.colors.purpleMain};
   ${applyMediaQuery('desktop', 'tablet')} {
     font-size: 1rem;
+  }
+  ${applyMediaQuery('mobile')} {
+    font-size: 1rem;
+    transform: scale(0.9);
+    transform-origin: center center;
   }
 `;
 
@@ -243,6 +281,9 @@ const LikeReview = styled.div`
   }
 
   ${applyMediaQuery('desktop', 'tablet')} {
+    margin-right: 1.5rem;
+  }
+  ${applyMediaQuery('mobile')} {
     margin-right: 1.5rem;
   }
 `;
@@ -264,6 +305,10 @@ const ReviewTextInfo = styled.div`
   ${applyMediaQuery('desktop', 'tablet')} {
     margin: 0;
     padding: 2rem 2.5rem;
+  }
+  ${applyMediaQuery('mobile')} {
+    margin: 0;
+    padding: 1.2rem 1.4rem;
   }
 `;
 
@@ -294,6 +339,22 @@ const ReviewProductInfo = styled.div`
       margin-left: 0.6rem;
     }
   }
+  ${applyMediaQuery('mobile')} {
+    margin: 0;
+    margin-bottom: 0.7rem;
+    font-size: 1rem;
+    transform: scale(0.8);
+    transform-origin: bottom left;
+    flex-direction: column;
+    gap: 0.2rem;
+    & > p:after {
+      content: '';
+    }
+    & > p {
+      height: 1.4rem;
+      margin-bottom: 0.2rem;
+    }
+  }
 `;
 
 const ReviewContent = styled.p`
@@ -307,6 +368,10 @@ const ReviewContent = styled.p`
     font-size: 1.2rem;
     line-height: 2.5rem;
   }
+  ${applyMediaQuery('mobile')} {
+    font-size: 1rem;
+    line-height: 2rem;
+  }
 `;
 
 const ReviewTagList = styled.div`
@@ -315,6 +380,10 @@ const ReviewTagList = styled.div`
   padding-top: 0;
   ${applyMediaQuery('desktop', 'tablet')} {
     padding: 2.5rem;
+    padding-top: 0;
+  }
+  ${applyMediaQuery('mobile')} {
+    padding: 1.4rem;
     padding-top: 0;
   }
 `;
@@ -337,6 +406,15 @@ const ReviewTag = styled.span`
     margin-right: 0.8rem;
     padding: 0 0.7rem;
     font-size: 1rem;
+  }
+  ${applyMediaQuery('mobile')} {
+    height: 2rem;
+    line-height: 1.6rem;
+    margin-right: 0;
+    padding: 0 0.8rem;
+    font-size: 1rem;
+    transform: scale(0.8);
+    transform-origin: bottom left;
   }
 `;
 

--- a/src/components/review/ShopSearch.tsx
+++ b/src/components/review/ShopSearch.tsx
@@ -120,7 +120,7 @@ const StyledRoot = styled.div`
       cursor: pointer;
     }
   }
-  ${applyMediaQuery('desktop', 'tablet')} {
+  ${applyMediaQuery('desktop', 'tablet', 'mobile')} {
     .search-icon {
       width: 1.7rem;
       height: 1.7rem;
@@ -167,7 +167,7 @@ const StyledWrapper = styled.div`
       font-family: 'Noto Sans KR';
     }
   }
-  ${applyMediaQuery('desktop', 'tablet')} {
+  ${applyMediaQuery('desktop', 'tablet', 'mobile')} {
     width: 32.5rem;
     height: 3.2rem;
     padding: 0 1rem;
@@ -182,5 +182,11 @@ const StyledWrapper = styled.div`
         line-height: 1.3rem;
       }
     }
+  }
+  ${applyMediaQuery('mobile')} {
+    width: 31.2rem;
+    height: 3.6rem;
+    padding: 0 1.2rem;
+    margin-bottom: 0.8rem;
   }
 `;

--- a/src/components/review/ShopSearchList.tsx
+++ b/src/components/review/ShopSearchList.tsx
@@ -67,7 +67,7 @@ const StyledUl = styled.ul`
   & > li:hover {
     background-color: ${theme.colors.purpleBg};
   }
-  ${applyMediaQuery('desktop', 'tablet')} {
+  ${applyMediaQuery('desktop', 'tablet', 'mobile')} {
     top: 3.7rem;
     width: 32.5rem;
     max-height: 30rem;
@@ -83,5 +83,11 @@ const StyledUl = styled.ul`
       font-size: 1rem;
       padding-left: 0.5rem;
     }
+  }
+  ${applyMediaQuery('mobile')} {
+    top: 3.7rem;
+    width: 31.2rem;
+    max-height: 10.5rem;
+    padding: 0.6rem;
   }
 `;

--- a/src/components/review/WriteItems/BuyList.tsx
+++ b/src/components/review/WriteItems/BuyList.tsx
@@ -47,4 +47,7 @@ const StyledRoot = styled.div`
   ${applyMediaQuery('desktop', 'tablet')} {
     gap: 1.1rem;
   }
+  ${applyMediaQuery('mobile')} {
+    gap: 1rem;
+  }
 `;

--- a/src/components/review/WriteItems/DropdownItem.tsx
+++ b/src/components/review/WriteItems/DropdownItem.tsx
@@ -75,7 +75,7 @@ const StyledRoot = styled.div`
     position: relative;
     width: 1.4rem;
     height: 1rem;
-    ${applyMediaQuery('desktop', 'tablet')} {
+    ${applyMediaQuery('desktop', 'tablet', 'mobile')} {
       width: 0.9rem;
       height: 0.6rem;
     }
@@ -99,7 +99,7 @@ const StyledWrapper = styled.div<{ isSelected: boolean }>`
     line-height: 2rem;
   }
 
-  ${applyMediaQuery('desktop', 'tablet')} {
+  ${applyMediaQuery('desktop', 'tablet', 'mobile')} {
     width: 18.8rem;
     height: 3.1rem;
     padding: 0 1.2rem;
@@ -108,5 +108,10 @@ const StyledWrapper = styled.div<{ isSelected: boolean }>`
       font-size: 1rem;
       line-height: 1.3rem;
     }
+  }
+  ${applyMediaQuery('mobile')} {
+    width: 17.8rem;
+    height: 3.6rem;
+    padding: 0 1.2rem;
   }
 `;

--- a/src/components/review/WriteItems/DropdownPrice.tsx
+++ b/src/components/review/WriteItems/DropdownPrice.tsx
@@ -70,7 +70,7 @@ const StyledRoot = styled.div`
     position: relative;
     width: 1.4rem;
     height: 1rem;
-    ${applyMediaQuery('desktop', 'tablet')} {
+    ${applyMediaQuery('desktop', 'tablet', 'mobile')} {
       width: 0.9rem;
       height: 0.6rem;
     }
@@ -100,7 +100,7 @@ const StyledWrapper = styled.div<{ isSelected: boolean }>`
     line-height: 2rem;
   }
 
-  ${applyMediaQuery('desktop', 'tablet')} {
+  ${applyMediaQuery('desktop', 'tablet', 'mobile')} {
     width: 12.6rem;
     height: 3.1rem;
     padding: 0 1.2rem;
@@ -110,5 +110,9 @@ const StyledWrapper = styled.div<{ isSelected: boolean }>`
       font-size: 1rem;
       line-height: 1rem;
     }
+  }
+  ${applyMediaQuery('mobile')} {
+    width: 12.5rem;
+    height: 3.6rem;
   }
 `;

--- a/src/components/review/WriteItems/ItemsListDiv.tsx
+++ b/src/components/review/WriteItems/ItemsListDiv.tsx
@@ -52,7 +52,7 @@ const StyledUl = styled.ul`
     background-color: ${theme.colors.purpleBg};
   }
 
-  ${applyMediaQuery('desktop', 'tablet')} {
+  ${applyMediaQuery('desktop', 'tablet', 'mobile')} {
     top: 3.6rem;
     width: 18.8rem;
     padding: 0.8rem 0.6rem;
@@ -62,6 +62,14 @@ const StyledUl = styled.ul`
       line-height: 1.9rem;
       font-size: 1rem;
       padding: 0 0.6rem;
+    }
+  }
+  ${applyMediaQuery('mobile')} {
+    width: 17.8rem;
+
+    & > li {
+      height: 2.4rem;
+      line-height: 2.4rem;
     }
   }
 `;

--- a/src/components/review/WriteItems/PriceList.tsx
+++ b/src/components/review/WriteItems/PriceList.tsx
@@ -52,7 +52,7 @@ const StyledUl = styled.ul`
     background-color: ${theme.colors.purpleBg};
   }
 
-  ${applyMediaQuery('desktop', 'tablet')} {
+  ${applyMediaQuery('desktop', 'tablet', 'mobile')} {
     top: 3.6rem;
     width: 12.6rem;
     padding: 0.8rem 0.5rem;
@@ -62,6 +62,14 @@ const StyledUl = styled.ul`
       line-height: 1.9rem;
       font-size: 1rem;
       padding-left: 0.5rem;
+    }
+  }
+  ${applyMediaQuery('mobile')} {
+    width: 12.5rem;
+
+    & > li {
+      height: 2.4rem;
+      line-height: 2.4rem;
     }
   }
 `;

--- a/src/components/review/WriteItems/index.tsx
+++ b/src/components/review/WriteItems/index.tsx
@@ -50,4 +50,7 @@ const StyledRoot = styled.div`
   ${applyMediaQuery('desktop', 'tablet')} {
     gap: 1.3rem;
   }
+  ${applyMediaQuery('mobile')} {
+    gap: 0.8rem;
+  }
 `;

--- a/src/components/review/write/PreviewImageList.tsx
+++ b/src/components/review/write/PreviewImageList.tsx
@@ -96,6 +96,20 @@ const StyledRoot = styled.div`
       height: 5rem;
     }
   }
+  ${applyMediaQuery('mobile')} {
+    width: 31.2rem;
+    height: 5.5rem;
+    margin-bottom: 0.6rem;
+    transform: translateY(0.4rem);
+    .plus-icon {
+      width: 1.2rem;
+      height: 1.2rem;
+    }
+    .image-preview {
+      width: 3.3rem;
+      height: 3.3rem;
+    }
+  }
 `;
 const StyledInput = styled.input`
   width: 7.5rem;
@@ -110,6 +124,12 @@ const StyledInput = styled.input`
     width: 5rem;
     height: 5rem;
     margin-left: -5.6rem;
+  }
+  ${applyMediaQuery('mobile')} {
+    width: 3.3rem;
+    height: 3.3rem;
+    margin-left: -3.5rem;
+    transform: translateY(-1.3rem);
   }
 `;
 const StyledImageCard = styled.div`
@@ -132,6 +152,15 @@ const StyledImageCard = styled.div`
   ${applyMediaQuery('desktop', 'tablet')} {
     width: 5rem;
   }
+  ${applyMediaQuery('mobile')} {
+    width: 3.3rem;
+    button {
+      transform: translate(0.8rem, 0.4rem);
+    }
+    svg path {
+      fill: ${theme.colors.purpleText};
+    }
+  }
 `;
 const StyledEmptyCard = styled.div`
   width: 7.5rem;
@@ -143,6 +172,11 @@ const StyledEmptyCard = styled.div`
   align-items: center;
   ${applyMediaQuery('desktop', 'tablet')} {
     width: 5rem;
+  }
+  ${applyMediaQuery('mobile')} {
+    width: 3.3rem;
+    height: 3.3rem;
+    transform: translateY(-1.3rem);
   }
 `;
 

--- a/src/components/review/write/PreviewImageMain.tsx
+++ b/src/components/review/write/PreviewImageMain.tsx
@@ -127,6 +127,31 @@ const StyledRoot = styled.div`
       margin-left: 1rem;
     }
   }
+  ${applyMediaQuery('mobile')} {
+    width: 31.2rem;
+    height: 24.8rem;
+    margin-bottom: 0.8rem;
+    .image-preview {
+      width: 31.2rem;
+      height: 24.8rem;
+    }
+    .camera-icon {
+      width: 4.8rem;
+      height: 3.7rem;
+    }
+    .main-icon {
+      width: 4.3rem;
+    }
+    .replace-icon {
+      width: 2rem;
+      height: 2rem;
+    }
+    .delete-icon {
+      width: 2rem;
+      height: 2rem;
+      margin-left: 1.5rem;
+    }
+  }
 `;
 const StyledIcons = styled.div`
   position: relative;
@@ -155,6 +180,9 @@ const StyledIcons = styled.div`
       margin-left: 10px;
     }
   }
+  ${applyMediaQuery('mobile')} {
+    margin-top: -24.8rem;
+  }
 `;
 const StyledReplace = styled.input`
   width: 2rem;
@@ -177,6 +205,9 @@ const StyledInput = styled.input`
   opacity: 0;
   ${applyMediaQuery('desktop', 'tablet')} {
     margin-top: -16.4rem;
+  }
+  ${applyMediaQuery('mobile')} {
+    margin-top: -24.8rem;
   }
 `;
 const StyledPreview = styled.div`
@@ -207,7 +238,7 @@ const StyledEmpty = styled.div`
     font-size: 1.2rem;
     font-weight: 500;
   }
-  ${applyMediaQuery('desktop', 'tablet')} {
+  ${applyMediaQuery('desktop', 'tablet', 'mobile')} {
     padding-top: 0;
     & p:nth-child(2) {
       font-size: 1rem;
@@ -217,6 +248,12 @@ const StyledEmpty = styled.div`
     & p:nth-child(3) {
       font-size: 1rem;
       transform: scale(0.8);
+    }
+  }
+  ${applyMediaQuery('mobile')} {
+    & p:nth-child(2) {
+      margin-top: 1.6rem;
+      margin-bottom: 0.4rem;
     }
   }
 `;

--- a/src/components/review/write/ReviewText.tsx
+++ b/src/components/review/write/ReviewText.tsx
@@ -38,7 +38,7 @@ const StyledRoot = styled.div`
     float: right;
     margin-right: 2.2rem;
   }
-  ${applyMediaQuery('desktop', 'tablet')} {
+  ${applyMediaQuery('desktop', 'tablet', 'mobile')} {
     width: 52.9rem;
     height: 17.3rem;
     padding: 1.5rem;
@@ -50,6 +50,14 @@ const StyledRoot = styled.div`
       line-height: 1.1rem;
       margin-right: 0;
       margin-top: 0.6rem;
+    }
+  }
+  ${applyMediaQuery('mobile')} {
+    width: 31.2rem;
+    height: 26rem;
+    margin-top: 0%;
+    p {
+      line-height: 1.7rem;
     }
   }
 `;
@@ -83,7 +91,7 @@ const StyledTextArea = styled.textarea`
       background: ${theme.colors.gray1};
     }
   }
-  ${applyMediaQuery('desktop', 'tablet')} {
+  ${applyMediaQuery('desktop', 'tablet', 'mobile')} {
     width: 100%;
     height: 100%;
     font-size: 1.2rem;
@@ -92,6 +100,9 @@ const StyledTextArea = styled.textarea`
     ::-webkit-scrollbar {
       width: 0.4rem;
     }
+  }
+  ${applyMediaQuery('mobile')} {
+    font-size: 1rem;
   }
 `;
 

--- a/src/components/review/write/SubmitButton.tsx
+++ b/src/components/review/write/SubmitButton.tsx
@@ -44,6 +44,13 @@ const StyledButton = styled.button<StyledProps>`
     margin-top: 4.5rem;
     margin-bottom: 5.4rem;
   }
+  ${applyMediaQuery('mobile')} {
+    width: 31.2rem;
+    height: 4.3rem;
+    font-size: 1.2rem;
+    margin-top: 5rem;
+    margin-bottom: 6.4rem;
+  }
 `;
 
 export default SubmitButton;

--- a/src/components/review/write/TagList.tsx
+++ b/src/components/review/write/TagList.tsx
@@ -68,6 +68,15 @@ const StyledRoot = styled.div`
     height: 2.8rem;
     padding: 0.5rem 1rem;
   }
+  ${applyMediaQuery('mobile')} {
+    width: 31.2rem;
+    height: 3rem;
+    padding: 0.6rem 1.2rem;
+    overflow-x: scroll;
+    &::-webkit-scrollbar {
+      display: none;
+    }
+  }
 `;
 const StyledInput = styled.input`
   font-family: 'Noto Sans KR';
@@ -82,8 +91,9 @@ const StyledInput = styled.input`
   &:focus {
     outline: none;
   }
-  ${applyMediaQuery('desktop', 'tablet')} {
+  ${applyMediaQuery('desktop', 'tablet', 'mobile')} {
     font-size: 1rem;
+    min-width: 1rem;
   }
 `;
 const StyledTag = styled.div`
@@ -106,12 +116,19 @@ const StyledTag = styled.div`
     content: '#';
   }
 
-  ${applyMediaQuery('desktop', 'tablet')} {
+  ${applyMediaQuery('desktop', 'tablet', 'mobile')} {
     font-size: 1rem;
     line-height: 1.6rem;
     padding: 0 0.7rem;
     height: 1.8rem;
     margin-right: 0.5rem;
+  }
+  ${applyMediaQuery('mobile')} {
+    height: 1.7rem;
+    line-height: 1.5rem;
+    margin-right: 0;
+    transform: scale(0.9);
+    transform-origin: center left;
   }
 `;
 

--- a/src/components/review/write/Title.tsx
+++ b/src/components/review/write/Title.tsx
@@ -50,6 +50,21 @@ const StyledRoot = styled.div`
       line-height: 1.3rem;
     }
   }
+  ${applyMediaQuery('mobile')} {
+    h2 {
+      font-size: 1.4rem;
+      line-height: 2rem;
+      margin-top: 1.4rem;
+      margin-bottom: 0.5rem;
+    }
+    p {
+      font-size: 1rem;
+      line-height: 1.3rem;
+      transform: scale(0.9);
+      transform-origin: top left;
+      width: 34rem;
+    }
+  }
 `;
 
 export default Title;

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -126,6 +126,9 @@ const Container = styled.main`
   ${applyMediaQuery('desktop')} {
     gap: 7.5rem;
   }
+  ${applyMediaQuery('tablet')} {
+    gap: 5.6rem;
+  }
   ${applyMediaQuery('mobile')} {
     gap: 3.6rem;
   }
@@ -145,6 +148,10 @@ const Label = styled.h2`
     font-size: 2.6rem;
     line-height: 3.8rem;
   }
+  ${applyMediaQuery('tablet')} {
+    font-size: 2rem;
+    line-height: 2.9rem;
+  }
   ${applyMediaQuery('mobile')} {
     font-size: 1.4rem;
     line-height: 2rem;
@@ -158,6 +165,9 @@ const LabelContentWrapper = styled.div`
 
   ${applyMediaQuery('desktop')} {
     gap: 2rem;
+  }
+  ${applyMediaQuery('tablet')} {
+    gap: 1.8rem;
   }
   ${applyMediaQuery('mobile')} {
     gap: 1.6rem;

--- a/src/pages/map/index.tsx
+++ b/src/pages/map/index.tsx
@@ -19,6 +19,9 @@ const StyledContainer = styled.main`
   flex-direction: column;
   margin: 7.2rem 0 13.4rem 0;
 
+  ${applyMediaQuery('tablet')} {
+    margin-top: 3rem;
+  }
   ${applyMediaQuery('mobile')} {
     margin: 1.4rem 0 13.4rem 0;
   }
@@ -36,6 +39,10 @@ const Header = styled.h1`
     color: ${({ theme }) => theme.colors.purpleText};
   }
 
+  ${applyMediaQuery('tablet')} {
+    font-size: 2rem;
+    line-height: 2.9rem;
+  }
   ${applyMediaQuery('mobile')} {
     font-size: 1.4rem;
     line-height: 2rem;
@@ -49,6 +56,11 @@ const SubHeader = styled.p`
   color: ${({ theme }) => theme.colors.black1};
   margin-bottom: 5.2rem;
 
+  ${applyMediaQuery('tablet')} {
+    font-size: 1.4rem;
+    line-height: 2rem;
+    margin-bottom: 10rem;
+  }
   ${applyMediaQuery('mobile')} {
     font-size: 1rem;
     line-height: 1.4rem;

--- a/src/pages/review/detail/[reviewId].tsx
+++ b/src/pages/review/detail/[reviewId].tsx
@@ -108,6 +108,11 @@ const StyledReviewDetailWrapper = styled.div`
     margin: 5.2rem auto;
     margin-bottom: 6rem;
   }
+  ${applyMediaQuery('mobile')} {
+    width: 31.2rem;
+    margin: 2.5rem auto;
+    margin-bottom: 3.5rem;
+  }
 `;
 
 const OtherReviewCardWrapper = styled.div``;
@@ -124,6 +129,9 @@ const HeaderTitle = styled.h3`
   ${applyMediaQuery('desktop', 'tablet')} {
     font-size: 2rem;
   }
+  ${applyMediaQuery('mobile')} {
+    font-size: 1.4rem;
+  }
 `;
 
 const ReviewListContent = styled.div`
@@ -131,6 +139,9 @@ const ReviewListContent = styled.div`
   width: 100%;
   ${applyMediaQuery('desktop', 'tablet')} {
     margin-top: 1.8rem;
+  }
+  ${applyMediaQuery('mobile')} {
+    margin-top: 1.6rem;
   }
 `;
 

--- a/src/pages/review/my/scrap.tsx
+++ b/src/pages/review/my/scrap.tsx
@@ -32,7 +32,12 @@ function Scrap() {
           <h2>스크랩한 리뷰</h2>
           <StyledCardWrapper>
             {reviewMyScrapList.map((review) => (
-              <ReviewCard key={review.reviewId} reviewData={review} isHoverAvailable />
+              <ReviewCard
+                key={review.reviewId}
+                reviewData={review}
+                isHoverAvailable
+                isMyReviewMobile
+              />
             ))}
           </StyledCardWrapper>
         </>

--- a/src/pages/review/my/scrap.tsx
+++ b/src/pages/review/my/scrap.tsx
@@ -67,6 +67,13 @@ const StyledContainer = styled.div`
       line-height: 3.8rem;
     }
   }
+  ${applyMediaQuery('tablet')} {
+    margin-top: 3rem;
+    & > h2 {
+      font-size: 2rem;
+      line-height: 2.9rem;
+    }
+  }
   ${applyMediaQuery('mobile')} {
     margin-top: 2.4rem;
     & > h2 {

--- a/src/pages/review/my/write.tsx
+++ b/src/pages/review/my/write.tsx
@@ -37,7 +37,13 @@ function Write() {
           <StyledCardWrapper>
             {reviewMyWriteList &&
               reviewMyWriteList.map((review) => (
-                <ReviewCard key={review.reviewId} reviewData={review} isHoverAvailable isMyReview />
+                <ReviewCard
+                  key={review.reviewId}
+                  reviewData={review}
+                  isHoverAvailable
+                  isMyReview
+                  isMyReviewMobile
+                />
               ))}
           </StyledCardWrapper>
         </>

--- a/src/pages/review/my/write.tsx
+++ b/src/pages/review/my/write.tsx
@@ -73,6 +73,13 @@ const StyledContainer = styled.div`
       line-height: 3.8rem;
     }
   }
+  ${applyMediaQuery('tablet')} {
+    margin-top: 3rem;
+    & > h2 {
+      font-size: 2rem;
+      line-height: 2.9rem;
+    }
+  }
   ${applyMediaQuery('mobile')} {
     margin: 2.5rem 0;
     & > h2 {

--- a/src/pages/review/write.tsx
+++ b/src/pages/review/write.tsx
@@ -14,6 +14,7 @@ import { parseShopId, parseShopName } from 'pages/review/detail/[reviewId]';
 import { useEffect, useState } from 'react';
 import styled from 'styled-components';
 import { applyMediaQuery } from 'styles/mediaQuery';
+import Screen from 'styles/Screen';
 import { Item, ReviewImage, ReviewWriteKey, ReviewWriteRequest } from 'types/review';
 import { PriceOptionList, ShopCategoryType } from 'types/shop';
 
@@ -195,6 +196,14 @@ function Write(props: WriteProps) {
           handleImageDelete={handleImageDelete}
         />
         <StyledTopRight>
+          <Screen mobile>
+            <PreviewImageList
+              reviewImageList={reviewImageList}
+              handleImageUpload={handleImageUpload}
+              handleImageDelete={handleImageDelete}
+              changeMainImage={changeMainImage}
+            />
+          </Screen>
           <ShopSearch
             selectedShop={reviewData.shopName}
             handleDataChange={handleDataChange}
@@ -203,12 +212,14 @@ function Write(props: WriteProps) {
           <WriteItems selectedItemList={reviewData.item} handleItemSubmit={handleItemSubmit} />
         </StyledTopRight>
       </StyledTop>
-      <PreviewImageList
-        reviewImageList={reviewImageList}
-        handleImageUpload={handleImageUpload}
-        handleImageDelete={handleImageDelete}
-        changeMainImage={changeMainImage}
-      />
+      <Screen wide desktop tablet>
+        <PreviewImageList
+          reviewImageList={reviewImageList}
+          handleImageUpload={handleImageUpload}
+          handleImageDelete={handleImageDelete}
+          changeMainImage={changeMainImage}
+        />
+      </Screen>
       <ReviewText content={reviewData.content} handleDataChange={handleDataChange} />
       <TagList
         tag={reviewData.tag}
@@ -232,6 +243,9 @@ const StyledRoot = styled.div`
   ${applyMediaQuery('desktop', 'tablet')} {
     width: 52.9rem;
   }
+  ${applyMediaQuery('mobile')} {
+    width: 31.2rem;
+  }
 `;
 const StyledTop = styled.div`
   display: flex;
@@ -241,6 +255,11 @@ const StyledTop = styled.div`
   ${applyMediaQuery('desktop', 'tablet')} {
     padding-top: 3rem;
     padding-bottom: 1.3rem;
+  }
+  ${applyMediaQuery('mobile')} {
+    padding-top: 1.7rem;
+    padding-bottom: 0.8rem;
+    flex-direction: column;
   }
 `;
 const StyledTopRight = styled.div`

--- a/src/pages/shop/collect.tsx
+++ b/src/pages/shop/collect.tsx
@@ -88,6 +88,13 @@ const StyledContainer = styled.div`
       line-height: 3.8rem;
     }
   }
+  ${applyMediaQuery('tablet')} {
+    margin-top: 3rem;
+    & > h2 {
+      font-size: 2rem;
+      line-height: 2.9rem;
+    }
+  }
   ${applyMediaQuery('mobile')} {
     margin-top: 1.4rem;
     & > h2 {

--- a/src/pages/shop/detail/[id].tsx
+++ b/src/pages/shop/detail/[id].tsx
@@ -11,6 +11,7 @@ import DetailShopAddress from 'components/ShopDetail/DetailShopAddress';
 import { reviewApi, useGetReviewByShopIdQuery } from 'features/reviews/reviewApi';
 import { useGetShopByShopIdQuery, useGetShopBySubwayQuery } from 'features/shops/shopApi';
 import useMap from 'hooks/useMap';
+import useMedia from 'hooks/useMedia';
 import { NextParsedUrlQuery } from 'next/dist/server/request-meta';
 import { useEffect, useRef, useState } from 'react';
 import styled from 'styled-components';
@@ -30,6 +31,8 @@ function Detail({ params }: { params: NextParsedUrlQuery; query: NextParsedUrlQu
   const SHOP_ID = parseShopId(params.id);
   const SORT_TYPE = 'like';
 
+  const { isMobile } = useMedia();
+
   const mapRef = useRef<HTMLDivElement>(null);
 
   const [currentPage, setCurrentPage] = useState(1);
@@ -38,7 +41,7 @@ function Detail({ params }: { params: NextParsedUrlQuery; query: NextParsedUrlQu
     shopId: SHOP_ID,
     sortType: SORT_TYPE,
     offset: currentPage,
-    limit: 9,
+    limit: isMobile ? 4 : 9,
   });
   const { data: subwayInfo } = useGetShopBySubwayQuery(SHOP_ID);
 
@@ -68,9 +71,11 @@ function Detail({ params }: { params: NextParsedUrlQuery; query: NextParsedUrlQu
 
       const cardList = shopList.map((shop) => <ShopCard key={shop.shopId} cardData={shop} />);
 
-      return <MainSlider slidesPerView={4} cardList={cardList} />;
+      return <MainSlider slidesPerView={getSlidesPerView()} cardList={cardList} isShopCard />;
     }
   };
+
+  const getSlidesPerView = () => (isMobile ? 2 : 4);
 
   const calcPageNum = () => {
     if (!reviewInfo) return 1;
@@ -78,8 +83,10 @@ function Detail({ params }: { params: NextParsedUrlQuery; query: NextParsedUrlQu
     const { reviewCount } = reviewInfo;
     if (!reviewCount) return 1;
 
-    const isElementRest = reviewCount % 9 > 0;
-    const page = Math.floor(reviewCount / 9);
+    const divider = isMobile ? 4 : 9;
+
+    const isElementRest = reviewCount % divider > 0;
+    const page = Math.floor(reviewCount / divider);
 
     return isElementRest ? page + 1 : page;
   };
@@ -102,7 +109,7 @@ function Detail({ params }: { params: NextParsedUrlQuery; query: NextParsedUrlQu
       shopId: SHOP_ID,
       sortType,
       offset: 1,
-      limit: 9,
+      limit: isMobile ? 4 : 9,
     });
     setCurrentList(result?.data?.data);
   };
@@ -213,6 +220,9 @@ const Wrapper = styled.div`
   flex-direction: column;
   width: 100%;
   gap: 9.6rem;
+  ${applyMediaQuery('mobile', 'tablet')} {
+    gap: 3.5rem;
+  }
 `;
 
 const MapContainer = styled.div`
@@ -290,6 +300,7 @@ const LabelContentWrapper = styled.div`
     gap: 4rem;
   }
   ${applyMediaQuery('tablet', 'mobile')} {
+    gap: 1.5rem;
   }
 `;
 
@@ -298,6 +309,10 @@ const ReviewGrid = styled.div`
   display: grid;
   grid-template-columns: repeat(3, minmax(0, 1fr));
   gap: 4rem 2.4rem;
+  ${applyMediaQuery('mobile')} {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 1.6rem 0.6rem;
+  }
 `;
 
 const LabelWithOptions = styled.div`

--- a/src/pages/shop/detail/[id].tsx
+++ b/src/pages/shop/detail/[id].tsx
@@ -31,7 +31,9 @@ function Detail({ params }: { params: NextParsedUrlQuery; query: NextParsedUrlQu
   const SHOP_ID = parseShopId(params.id);
   const SORT_TYPE = 'like';
 
-  const { isMobile } = useMedia();
+  const { isMobile, isTablet } = useMedia();
+  const getLimit = () => (isMobile ? 4 : isTablet ? 6 : 9);
+  const getSlidesPerView = () => (isMobile ? 2 : isTablet ? 3 : 4);
 
   const mapRef = useRef<HTMLDivElement>(null);
 
@@ -41,7 +43,7 @@ function Detail({ params }: { params: NextParsedUrlQuery; query: NextParsedUrlQu
     shopId: SHOP_ID,
     sortType: SORT_TYPE,
     offset: currentPage,
-    limit: isMobile ? 4 : 9,
+    limit: getLimit(),
   });
   const { data: subwayInfo } = useGetShopBySubwayQuery(SHOP_ID);
 
@@ -75,15 +77,13 @@ function Detail({ params }: { params: NextParsedUrlQuery; query: NextParsedUrlQu
     }
   };
 
-  const getSlidesPerView = () => (isMobile ? 2 : 4);
-
   const calcPageNum = () => {
     if (!reviewInfo) return 1;
 
     const { reviewCount } = reviewInfo;
     if (!reviewCount) return 1;
 
-    const divider = isMobile ? 4 : 9;
+    const divider = getLimit();
 
     const isElementRest = reviewCount % divider > 0;
     const page = Math.floor(reviewCount / divider);
@@ -109,7 +109,7 @@ function Detail({ params }: { params: NextParsedUrlQuery; query: NextParsedUrlQu
       shopId: SHOP_ID,
       sortType,
       offset: 1,
-      limit: isMobile ? 4 : 9,
+      limit: getLimit(),
     });
     setCurrentList(result?.data?.data);
   };
@@ -309,6 +309,10 @@ const ReviewGrid = styled.div`
   display: grid;
   grid-template-columns: repeat(3, minmax(0, 1fr));
   gap: 4rem 2.4rem;
+  ${applyMediaQuery('tablet')} {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 2.5rem 1.2rem;
+  }
   ${applyMediaQuery('mobile')} {
     grid-template-columns: repeat(2, minmax(0, 1fr));
     gap: 1.6rem 0.6rem;

--- a/src/pages/shop/detail/[id].tsx
+++ b/src/pages/shop/detail/[id].tsx
@@ -289,6 +289,8 @@ const LabelContentWrapper = styled.div`
   ${applyMediaQuery('desktop')} {
     gap: 4rem;
   }
+  ${applyMediaQuery('tablet', 'mobile')} {
+  }
 `;
 
 const ReviewGrid = styled.div`

--- a/src/pages/shop/theme/[type].tsx
+++ b/src/pages/shop/theme/[type].tsx
@@ -69,6 +69,9 @@ const Wrapper = styled.div`
   ${applyMediaQuery('desktop')} {
     padding-top: 5.2rem;
   }
+  ${applyMediaQuery('tablet')} {
+    padding-top: 3rem;
+  }
   ${applyMediaQuery('mobile')} {
     padding: 1.4rem 0;
   }
@@ -81,7 +84,7 @@ const ThemeWrapper = styled.div`
   width: 100%;
   display: flex;
   height: calc(50.8rem - 7.2rem);
-  ${applyMediaQuery('desktop')} {
+  ${applyMediaQuery('desktop', 'tablet')} {
     height: max-content;
     margin-bottom: 0.5rem;
   }
@@ -125,6 +128,10 @@ const DropDownWrapper = styled.div`
   ${applyMediaQuery('desktop')} {
     margin-top: 6.8rem;
     margin-bottom: 2.4rem;
+  }
+  ${applyMediaQuery('tablet')} {
+    margin-top: 3rem;
+    margin-bottom: 1.6rem;
   }
 `;
 


### PR DESCRIPTION
<!-- PR의 제목은 "[#이슈번호] 이슈이름" 으로 작성해주시면 되겠습니다 -->

## ✨ 구현 기능 명세
남은 모바일 + 태블릿 반응형을 모두 완료했습니다~
- 메인
- 리뷰 상세
- 소품샵 상세
- 리뷰 작성
- 빈 화면

## 🎁 PR Point
- 원래 소품샵 상세의 페이지네이션이 모바일에서는 '더보기' 버튼인데, 일단은 기능을 변경하지 않고 크기랑 한 화면에 보이는 카드 숫자만 조정했습니당... 나중에 릴리즈하고 시간 되면 변경해야 할 것 같아요..!
- 푸터 모바일에서 깨지길래 임의로 간격 조정했어요
- 태블릿뷰는 모바일과 데스크탑을 적절히 조합했어요

## 🕰 소요시간
- 6시간 정도

## 😭 어려웠던 점
- 태블릿뷰는 디자인이 아예 없고, 모바일뷰도 디자인이 생략되어있는 경우가 많아서(리뷰 작성같은 경우...) 그냥 임의로 개발한 부분이 많습니다 ㅠㅠ 리뷰 작성 모바일뷰는 추가적으로 요청해야 할 것 같네욤... ㅎㅎ 사진 삭제버튼을 둘 데가 없어서 밑으로 내려버렸거든요
