### PR TITLE
[FEATURE] E#A-S#5 무한스크롤 적용시키기

### DIFF
--- a/src/components/common/EmptyContent.tsx
+++ b/src/components/common/EmptyContent.tsx
@@ -6,7 +6,7 @@ import ImageDiv from './ImageDiv';
 
 interface EmptyContentProps {
   emptyContentData: {
-    title: string;
+    title?: string;
     src: string;
     label: string;
     subLabel: string;
@@ -22,7 +22,7 @@ function EmptyContent(props: EmptyContentProps) {
 
   return (
     <StyledContainer>
-      <Header>{title}</Header>
+      {title && <Header>{title}</Header>}
       <ContentWrapper>
         <ImageDiv className="shop_image_empty" layout="fill" src={src} alt="shop_image" />
         <Label>{label}</Label>

--- a/src/components/review/OtherReview/Container/index.tsx
+++ b/src/components/review/OtherReview/Container/index.tsx
@@ -12,6 +12,7 @@ function OtherReviewContainer(props: OtherReviewCardProps) {
 }
 
 const ReviewList = styled.div`
+  position: relative;
   display: grid;
   grid-template-columns: repeat(2, 1fr);
   column-gap: 1.6rem;

--- a/src/components/review/OtherReview/Presentation/OtherMyScrapReview.tsx
+++ b/src/components/review/OtherReview/Presentation/OtherMyScrapReview.tsx
@@ -2,11 +2,12 @@ import Loader from 'components/common/Loader';
 import ReviewCard from 'components/common/ReviewCard';
 import { useGetMyScrapReviewQuery } from 'features/reviews/reviewApi';
 import useInfiniteQuery from 'hooks/useInfiniteQuery';
-import { LoadPoint } from 'pages/shop/theme/[type]';
+import { LoadPoint as PrevLoadPoint } from 'pages/shop/theme/[type]';
 import { useEffect, useState } from 'react';
+import styled from 'styled-components';
 import { ReviewMyScrapResponse } from 'types/review';
 
-const PAGE_LIMIT = 4;
+const PAGE_LIMIT = 6;
 
 function OtherMyScrapReview({ reviewId }: { reviewId: number }) {
   const { data: myScrapResponse } = useGetMyScrapReviewQuery();
@@ -54,5 +55,12 @@ function OtherMyScrapReview({ reviewId }: { reviewId: number }) {
     </>
   );
 }
+
+const LoadPoint = styled(PrevLoadPoint)`
+  position: absolute;
+  bottom: 0;
+
+  transform: translateY(-100%);
+`;
 
 export default OtherMyScrapReview;

--- a/src/components/review/OtherReview/Presentation/OtherMyScrapReview.tsx
+++ b/src/components/review/OtherReview/Presentation/OtherMyScrapReview.tsx
@@ -1,18 +1,56 @@
+import Loader from 'components/common/Loader';
 import ReviewCard from 'components/common/ReviewCard';
 import { useGetMyScrapReviewQuery } from 'features/reviews/reviewApi';
+import useInfiniteQuery from 'hooks/useInfiniteQuery';
+import { LoadPoint } from 'pages/shop/theme/[type]';
+import { useEffect, useState } from 'react';
+import { ReviewMyScrapResponse } from 'types/review';
+
+const PAGE_LIMIT = 4;
 
 function OtherMyScrapReview({ reviewId }: { reviewId: number }) {
   const { data: myScrapResponse } = useGetMyScrapReviewQuery();
+
+  const [paginatedData, setPaginatedData] = useState<ReviewMyScrapResponse[][]>([]);
+  const [offset, setOffset] = useState(0);
+
+  const fetchNextData = () => {
+    if (paginatedData.length === offset + 1) return [];
+    setOffset((prevOffset) => prevOffset + 1);
+    return paginatedData[offset + 1];
+  };
+
+  const {
+    data: infiteMyScrapData,
+    isLoading,
+    loadPointRef,
+  } = useInfiniteQuery(paginatedData[0], fetchNextData, {});
+
+  useEffect(() => {
+    if (myScrapResponse) {
+      const initialPaginatedData = myScrapResponse.reduce(
+        (acc, cur, idx) => {
+          const currentPage = Math.floor(idx / PAGE_LIMIT);
+          const currentPageData = acc[currentPage] ? [...acc[currentPage], cur] : [cur];
+          return [...acc.slice(0, currentPage), currentPageData];
+        },
+        [[]] as ReviewMyScrapResponse[][],
+      );
+
+      setPaginatedData(initialPaginatedData);
+    }
+  }, [myScrapResponse]);
 
   if (!myScrapResponse) return <div />; // 로더 삽입하면 좋을 것 같음.
 
   return (
     <>
-      {myScrapResponse
+      {infiteMyScrapData
         .filter((_) => _.reviewId !== reviewId)
         .map((myScrapReview) => (
           <ReviewCard key={myScrapReview.shopId} reviewData={myScrapReview} />
         ))}
+      <LoadPoint ref={loadPointRef}>{isLoading && <Loader />}</LoadPoint>
     </>
   );
 }

--- a/src/components/review/OtherReview/Presentation/OtherMyScrapReview.tsx
+++ b/src/components/review/OtherReview/Presentation/OtherMyScrapReview.tsx
@@ -19,7 +19,7 @@ function OtherMyScrapReview({ reviewId }: { reviewId: number }) {
     return paginatedData[offset + 1];
   };
 
-  const { renderCurrentData } = useInfiniteQuery(paginatedData[0], fetchNextData, {}, (scrapList) =>
+  const { renderCurrentData } = useInfiniteQuery(paginatedData[0], fetchNextData, (scrapList) =>
     scrapList
       .filter((_) => _.reviewId !== reviewId)
       .map((myScrapReview) => <ReviewCard key={myScrapReview.shopId} reviewData={myScrapReview} />),

--- a/src/components/review/OtherReview/Presentation/OtherMyScrapReview.tsx
+++ b/src/components/review/OtherReview/Presentation/OtherMyScrapReview.tsx
@@ -2,9 +2,7 @@ import Loader from 'components/common/Loader';
 import ReviewCard from 'components/common/ReviewCard';
 import { useGetMyScrapReviewQuery } from 'features/reviews/reviewApi';
 import useInfiniteQuery from 'hooks/useInfiniteQuery';
-import { LoadPoint as PrevLoadPoint } from 'pages/shop/theme/[type]';
 import { useEffect, useState } from 'react';
-import styled from 'styled-components';
 import { ReviewMyScrapResponse } from 'types/review';
 
 const PAGE_LIMIT = 6;
@@ -21,11 +19,11 @@ function OtherMyScrapReview({ reviewId }: { reviewId: number }) {
     return paginatedData[offset + 1];
   };
 
-  const {
-    data: infiteMyScrapData,
-    isLoading,
-    loadPointRef,
-  } = useInfiniteQuery(paginatedData[0], fetchNextData, {});
+  const { renderCurrentData } = useInfiniteQuery(paginatedData[0], fetchNextData, {}, (scrapList) =>
+    scrapList
+      .filter((_) => _.reviewId !== reviewId)
+      .map((myScrapReview) => <ReviewCard key={myScrapReview.shopId} reviewData={myScrapReview} />),
+  );
 
   useEffect(() => {
     if (myScrapResponse) {
@@ -42,25 +40,9 @@ function OtherMyScrapReview({ reviewId }: { reviewId: number }) {
     }
   }, [myScrapResponse]);
 
-  if (!myScrapResponse) return <div />; // 로더 삽입하면 좋을 것 같음.
+  if (!myScrapResponse) return <Loader />;
 
-  return (
-    <>
-      {infiteMyScrapData
-        .filter((_) => _.reviewId !== reviewId)
-        .map((myScrapReview) => (
-          <ReviewCard key={myScrapReview.shopId} reviewData={myScrapReview} />
-        ))}
-      <LoadPoint ref={loadPointRef}>{isLoading && <Loader />}</LoadPoint>
-    </>
-  );
+  return renderCurrentData();
 }
-
-const LoadPoint = styled(PrevLoadPoint)`
-  position: absolute;
-  bottom: 0;
-
-  transform: translateY(-100%);
-`;
 
 export default OtherMyScrapReview;

--- a/src/components/review/OtherReview/Presentation/OtherMyScrapReview.tsx
+++ b/src/components/review/OtherReview/Presentation/OtherMyScrapReview.tsx
@@ -19,10 +19,15 @@ function OtherMyScrapReview({ reviewId }: { reviewId: number }) {
     return paginatedData[offset + 1];
   };
 
-  const { renderCurrentData } = useInfiniteQuery(paginatedData[0], fetchNextData, (scrapList) =>
-    scrapList
-      .filter((_) => _.reviewId !== reviewId)
-      .map((myScrapReview) => <ReviewCard key={myScrapReview.shopId} reviewData={myScrapReview} />),
+  const { renderCurrentData, loadPoint } = useInfiniteQuery(
+    paginatedData[0],
+    fetchNextData,
+    (scrapList) =>
+      scrapList
+        .filter((_) => _.reviewId !== reviewId)
+        .map((myScrapReview) => (
+          <ReviewCard key={myScrapReview.shopId} reviewData={myScrapReview} />
+        )),
   );
 
   useEffect(() => {
@@ -42,7 +47,12 @@ function OtherMyScrapReview({ reviewId }: { reviewId: number }) {
 
   if (!myScrapResponse) return <Loader />;
 
-  return renderCurrentData();
+  return (
+    <>
+      {renderCurrentData()}
+      {loadPoint}
+    </>
+  );
 }
 
 export default OtherMyScrapReview;

--- a/src/components/review/OtherReview/Presentation/OtherMyWriteReview.tsx
+++ b/src/components/review/OtherReview/Presentation/OtherMyWriteReview.tsx
@@ -2,9 +2,7 @@ import Loader from 'components/common/Loader';
 import ReviewCard from 'components/common/ReviewCard';
 import { useGetMyWriteReviewQuery } from 'features/reviews/reviewApi';
 import useInfiniteQuery from 'hooks/useInfiniteQuery';
-import { LoadPoint as PrevLoadPoint } from 'pages/shop/theme/[type]';
 import { useEffect, useState } from 'react';
-import styled from 'styled-components';
 import { ReviewMyWriteResponse } from 'types/review';
 
 const PAGE_LIMIT = 4;
@@ -21,11 +19,11 @@ function OtherMyWriteReview({ reviewId }: { reviewId: number }) {
     return paginatedData[offset + 1];
   };
 
-  const {
-    data: infiniteMyWriteData,
-    isLoading,
-    loadPointRef,
-  } = useInfiniteQuery(paginatedData[0], fetchNextData, {});
+  const { renderCurrentData } = useInfiniteQuery(paginatedData[0], fetchNextData, {}, (writeList) =>
+    writeList
+      .filter((_) => _.reviewId !== reviewId)
+      .map((myWriteReview) => <ReviewCard key={myWriteReview.shopId} reviewData={myWriteReview} />),
+  );
 
   useEffect(() => {
     if (myWriteResponse) {
@@ -42,25 +40,9 @@ function OtherMyWriteReview({ reviewId }: { reviewId: number }) {
     }
   }, [myWriteResponse]);
 
-  if (!myWriteResponse) return <div />; // 로더 삽입하면 좋을 것 같음.
+  if (!myWriteResponse) return <Loader />;
 
-  return (
-    <>
-      {infiniteMyWriteData
-        .filter((_) => _.reviewId !== reviewId)
-        .map((myWriteReview) => (
-          <ReviewCard key={myWriteReview.shopId} reviewData={myWriteReview} />
-        ))}
-      <LoadPoint ref={loadPointRef}>{isLoading && <Loader />}</LoadPoint>
-    </>
-  );
+  return renderCurrentData();
 }
-
-const LoadPoint = styled(PrevLoadPoint)`
-  position: absolute;
-  bottom: 0;
-
-  transform: translateY(-100%);
-`;
 
 export default OtherMyWriteReview;

--- a/src/components/review/OtherReview/Presentation/OtherMyWriteReview.tsx
+++ b/src/components/review/OtherReview/Presentation/OtherMyWriteReview.tsx
@@ -19,7 +19,7 @@ function OtherMyWriteReview({ reviewId }: { reviewId: number }) {
     return paginatedData[offset + 1];
   };
 
-  const { renderCurrentData } = useInfiniteQuery(paginatedData[0], fetchNextData, {}, (writeList) =>
+  const { renderCurrentData } = useInfiniteQuery(paginatedData[0], fetchNextData, (writeList) =>
     writeList
       .filter((_) => _.reviewId !== reviewId)
       .map((myWriteReview) => <ReviewCard key={myWriteReview.shopId} reviewData={myWriteReview} />),

--- a/src/components/review/OtherReview/Presentation/OtherMyWriteReview.tsx
+++ b/src/components/review/OtherReview/Presentation/OtherMyWriteReview.tsx
@@ -1,20 +1,66 @@
+import Loader from 'components/common/Loader';
 import ReviewCard from 'components/common/ReviewCard';
 import { useGetMyWriteReviewQuery } from 'features/reviews/reviewApi';
+import useInfiniteQuery from 'hooks/useInfiniteQuery';
+import { LoadPoint as PrevLoadPoint } from 'pages/shop/theme/[type]';
+import { useEffect, useState } from 'react';
+import styled from 'styled-components';
+import { ReviewMyWriteResponse } from 'types/review';
+
+const PAGE_LIMIT = 4;
 
 function OtherMyWriteReview({ reviewId }: { reviewId: number }) {
   const { data: myWriteResponse } = useGetMyWriteReviewQuery();
+
+  const [paginatedData, setPaginatedData] = useState<ReviewMyWriteResponse[][]>([]);
+  const [offset, setOffset] = useState(0);
+
+  const fetchNextData = () => {
+    if (paginatedData.length === offset + 1) return [];
+    setOffset((prevOffset) => prevOffset + 1);
+    return paginatedData[offset + 1];
+  };
+
+  const {
+    data: infiniteMyWriteData,
+    isLoading,
+    loadPointRef,
+  } = useInfiniteQuery(paginatedData[0], fetchNextData, {});
+
+  useEffect(() => {
+    if (myWriteResponse) {
+      const initialPaginatedData = myWriteResponse.reduce(
+        (acc, cur, idx) => {
+          const currentPage = Math.floor(idx / PAGE_LIMIT);
+          const currentPageData = acc[currentPage] ? [...acc[currentPage], cur] : [cur];
+          return [...acc.slice(0, currentPage), currentPageData];
+        },
+        [[]] as ReviewMyWriteResponse[][],
+      );
+
+      setPaginatedData(initialPaginatedData);
+    }
+  }, [myWriteResponse]);
 
   if (!myWriteResponse) return <div />; // 로더 삽입하면 좋을 것 같음.
 
   return (
     <>
-      {myWriteResponse
+      {infiniteMyWriteData
         .filter((_) => _.reviewId !== reviewId)
         .map((myWriteReview) => (
           <ReviewCard key={myWriteReview.shopId} reviewData={myWriteReview} />
         ))}
+      <LoadPoint ref={loadPointRef}>{isLoading && <Loader />}</LoadPoint>
     </>
   );
 }
+
+const LoadPoint = styled(PrevLoadPoint)`
+  position: absolute;
+  bottom: 0;
+
+  transform: translateY(-100%);
+`;
 
 export default OtherMyWriteReview;

--- a/src/components/review/OtherReview/Presentation/OtherMyWriteReview.tsx
+++ b/src/components/review/OtherReview/Presentation/OtherMyWriteReview.tsx
@@ -19,10 +19,15 @@ function OtherMyWriteReview({ reviewId }: { reviewId: number }) {
     return paginatedData[offset + 1];
   };
 
-  const { renderCurrentData } = useInfiniteQuery(paginatedData[0], fetchNextData, (writeList) =>
-    writeList
-      .filter((_) => _.reviewId !== reviewId)
-      .map((myWriteReview) => <ReviewCard key={myWriteReview.shopId} reviewData={myWriteReview} />),
+  const { renderCurrentData, loadPoint } = useInfiniteQuery(
+    paginatedData[0],
+    fetchNextData,
+    (writeList) =>
+      writeList
+        .filter((_) => _.reviewId !== reviewId)
+        .map((myWriteReview) => (
+          <ReviewCard key={myWriteReview.shopId} reviewData={myWriteReview} />
+        )),
   );
 
   useEffect(() => {
@@ -42,7 +47,12 @@ function OtherMyWriteReview({ reviewId }: { reviewId: number }) {
 
   if (!myWriteResponse) return <Loader />;
 
-  return renderCurrentData();
+  return (
+    <>
+      {renderCurrentData()}
+      {loadPoint}
+    </>
+  );
 }
 
 export default OtherMyWriteReview;

--- a/src/components/review/OtherReview/Presentation/OtherShopReview.tsx
+++ b/src/components/review/OtherReview/Presentation/OtherShopReview.tsx
@@ -2,7 +2,9 @@ import Loader from 'components/common/Loader';
 import ReviewCard from 'components/common/ReviewCard';
 import { reviewApi, useGetReviewByShopIdQuery } from 'features/reviews/reviewApi';
 import useInfiniteQuery from 'hooks/useInfiniteQuery';
+import { LoadPoint as PrevLoadPoint } from 'pages/shop/theme/[type]';
 import { useCallback } from 'react';
+import styled from 'styled-components';
 import { ReviewByShopIdData, ReviewShopIdRequestParams } from 'types/review';
 
 function OtherShopReview({
@@ -15,13 +17,16 @@ function OtherShopReview({
   const { data: reviewResponseFirst } = useGetReviewByShopIdQuery(reqInfo, { skip: !reqInfo });
   const [getReviewByShopId] = reviewApi.endpoints.getReviewByShopId.useLazyQuery();
 
-  const fetchFn = useCallback(async (offset: number) => {
-    const result = await getReviewByShopId({
-      ...reqInfo,
-      offset,
-    });
-    return result?.data || [];
-  }, []);
+  const fetchFn = useCallback(
+    async (offset: number) => {
+      const result = await getReviewByShopId({
+        ...reqInfo,
+        offset,
+      });
+      return result?.data || [];
+    },
+    [reqInfo],
+  );
 
   const {
     data: infiniteData,
@@ -29,7 +34,7 @@ function OtherShopReview({
     loadPointRef,
   } = useInfiniteQuery<ReviewByShopIdData>(reviewResponseFirst, fetchFn, {});
 
-  if (isDataLoading || !infiniteData) return <Loader />;
+  if (!infiniteData) return <Loader />;
   return (
     <>
       {infiniteData
@@ -37,9 +42,16 @@ function OtherShopReview({
         .map((reviewInfo) => (
           <ReviewCard key={reviewInfo.content} reviewData={reviewInfo} />
         ))}
-      <div ref={loadPointRef} />
+      <LoadPoint ref={loadPointRef}>{isDataLoading && <Loader />}</LoadPoint>
     </>
   );
 }
+
+const LoadPoint = styled(PrevLoadPoint)`
+  position: absolute;
+  bottom: 0;
+
+  transform: translateY(-100%);
+`;
 
 export default OtherShopReview;

--- a/src/components/review/OtherReview/Presentation/OtherShopReview.tsx
+++ b/src/components/review/OtherReview/Presentation/OtherShopReview.tsx
@@ -2,9 +2,7 @@ import Loader from 'components/common/Loader';
 import ReviewCard from 'components/common/ReviewCard';
 import { reviewApi, useGetReviewByShopIdQuery } from 'features/reviews/reviewApi';
 import useInfiniteQuery from 'hooks/useInfiniteQuery';
-import { LoadPoint as PrevLoadPoint } from 'pages/shop/theme/[type]';
 import { useCallback } from 'react';
-import styled from 'styled-components';
 import { ReviewByShopIdData, ReviewShopIdRequestParams } from 'types/review';
 
 function OtherShopReview({
@@ -28,30 +26,18 @@ function OtherShopReview({
     [reqInfo],
   );
 
-  const {
-    data: infiniteData,
-    isLoading: isDataLoading,
-    loadPointRef,
-  } = useInfiniteQuery<ReviewByShopIdData>(reviewResponseFirst, fetchFn, {});
+  const { data: infiniteData, renderCurrentData } = useInfiniteQuery<ReviewByShopIdData>(
+    reviewResponseFirst,
+    fetchFn,
+    {},
+    (reviewList) =>
+      reviewList
+        .filter((_) => _.reviewId !== reviewId)
+        .map((reviewInfo) => <ReviewCard key={reviewInfo.reviewId} reviewData={reviewInfo} />),
+  );
 
   if (!infiniteData) return <Loader />;
-  return (
-    <>
-      {infiniteData
-        .filter((_) => _.reviewId !== reviewId)
-        .map((reviewInfo) => (
-          <ReviewCard key={reviewInfo.content} reviewData={reviewInfo} />
-        ))}
-      <LoadPoint ref={loadPointRef}>{isDataLoading && <Loader />}</LoadPoint>
-    </>
-  );
+  return renderCurrentData();
 }
-
-const LoadPoint = styled(PrevLoadPoint)`
-  position: absolute;
-  bottom: 0;
-
-  transform: translateY(-100%);
-`;
 
 export default OtherShopReview;

--- a/src/components/review/OtherReview/Presentation/OtherShopReview.tsx
+++ b/src/components/review/OtherReview/Presentation/OtherShopReview.tsx
@@ -1,8 +1,8 @@
 import Loader from 'components/common/Loader';
 import ReviewCard from 'components/common/ReviewCard';
 import { reviewApi, useGetReviewByShopIdQuery } from 'features/reviews/reviewApi';
-import useObserver from 'hooks/useObserver';
-import { useEffect, useRef, useState } from 'react';
+import useInfiniteQuery from 'hooks/useInfiniteQuery';
+import { useCallback } from 'react';
 import { ReviewByShopIdData, ReviewShopIdRequestParams } from 'types/review';
 
 function OtherShopReview({
@@ -15,50 +15,29 @@ function OtherShopReview({
   const { data: reviewResponseFirst } = useGetReviewByShopIdQuery(reqInfo, { skip: !reqInfo });
   const [getReviewByShopId] = reviewApi.endpoints.getReviewByShopId.useLazyQuery();
 
-  const [reviewResponse, setReviewResponse] = useState<ReviewByShopIdData[] | undefined>(
-    reviewResponseFirst?.data,
-  );
-  const [isLoading, setIsLoading] = useState(false);
+  const fetchFn = useCallback(async (offset: number) => {
+    const result = await getReviewByShopId({
+      ...reqInfo,
+      offset,
+    });
+    return result?.data || [];
+  }, []);
 
-  const bottomRef = useRef(null);
-  const offsetIndex = useRef(1);
+  const {
+    data: infiniteData,
+    isLoading: isDataLoading,
+    loadPointRef,
+  } = useInfiniteQuery<ReviewByShopIdData>(reviewResponseFirst, fetchFn, {});
 
-  useEffect(() => {
-    if (reviewResponseFirst) {
-      setReviewResponse(reviewResponseFirst.data);
-      setIsLoading(false);
-    } else {
-      setIsLoading(true);
-    }
-  }, [reviewResponseFirst]);
-
-  const onIntersect: IntersectionObserverCallback = async ([entry]) => {
-    if (entry.isIntersecting) {
-      offsetIndex.current += 1;
-      const { data: reviewResponseNext } = await getReviewByShopId({
-        ...reqInfo,
-        offset: offsetIndex.current,
-      });
-      if (!reviewResponseNext || !reviewResponse) {
-        setIsLoading(true);
-      } else {
-        reviewResponseNext.data.length > 0 &&
-          setReviewResponse([...reviewResponse, ...reviewResponseNext.data]);
-        setIsLoading(false);
-      }
-    }
-  };
-  useObserver({ target: bottomRef, onIntersect });
-
-  if (isLoading || !reviewResponse) return <Loader />;
+  if (isDataLoading || !infiniteData) return <Loader />;
   return (
     <>
-      {reviewResponse
+      {infiniteData
         .filter((_) => _.reviewId !== reviewId)
         .map((reviewInfo) => (
           <ReviewCard key={reviewInfo.content} reviewData={reviewInfo} />
         ))}
-      <div ref={bottomRef} />
+      <div ref={loadPointRef} />
     </>
   );
 }

--- a/src/components/review/OtherReview/Presentation/OtherShopReview.tsx
+++ b/src/components/review/OtherReview/Presentation/OtherShopReview.tsx
@@ -29,7 +29,6 @@ function OtherShopReview({
   const { data: infiniteData, renderCurrentData } = useInfiniteQuery<ReviewByShopIdData>(
     reviewResponseFirst,
     fetchFn,
-    {},
     (reviewList) =>
       reviewList
         .filter((_) => _.reviewId !== reviewId)

--- a/src/components/review/OtherReview/Presentation/OtherShopReview.tsx
+++ b/src/components/review/OtherReview/Presentation/OtherShopReview.tsx
@@ -26,17 +26,23 @@ function OtherShopReview({
     [reqInfo],
   );
 
-  const { data: infiniteData, renderCurrentData } = useInfiniteQuery<ReviewByShopIdData>(
-    reviewResponseFirst,
-    fetchFn,
-    (reviewList) =>
-      reviewList
-        .filter((_) => _.reviewId !== reviewId)
-        .map((reviewInfo) => <ReviewCard key={reviewInfo.reviewId} reviewData={reviewInfo} />),
+  const {
+    data: infiniteData,
+    renderCurrentData,
+    loadPoint,
+  } = useInfiniteQuery<ReviewByShopIdData>(reviewResponseFirst, fetchFn, (reviewList) =>
+    reviewList
+      .filter((_) => _.reviewId !== reviewId)
+      .map((reviewInfo) => <ReviewCard key={reviewInfo.reviewId} reviewData={reviewInfo} />),
   );
 
   if (!infiniteData) return <Loader />;
-  return renderCurrentData();
+  return (
+    <>
+      {renderCurrentData()}
+      {loadPoint}
+    </>
+  );
 }
 
 export default OtherShopReview;

--- a/src/hooks/useInfiniteQuery.tsx
+++ b/src/hooks/useInfiniteQuery.tsx
@@ -1,0 +1,83 @@
+import { useEffect, useRef, useState } from 'react';
+
+interface IUseObserver {
+  root?: HTMLElement;
+  rootMargin?: string;
+  threshold?: number;
+}
+
+type InitialDataType<DataType> = WrappedData<DataType> | DataType[] | undefined;
+
+interface WrappedData<DataType> {
+  data?: DataType[];
+}
+
+const useInfiniteQuery = <DataType,>(
+  initialData: InitialDataType<DataType>,
+  fetchFn: (offset: number) => Promise<InitialDataType<DataType>> | InitialDataType<DataType>,
+  props: IUseObserver,
+) => {
+  const isWrappedData = (data: InitialDataType<DataType>): data is WrappedData<DataType> =>
+    data !== undefined && 'data' in data;
+  const { root = null, rootMargin = '0px', threshold = 1 } = props;
+  const [data, setData] = useState(() =>
+    isWrappedData(initialData) ? initialData?.data || [] : initialData || [],
+  );
+  const [isLoading, setIsLoading] = useState(false);
+  const [isLastData, setIsLastData] = useState(false);
+  const loadPointRef = useRef(null);
+  const offsetIndex = useRef(1);
+
+  const unwrapDataIfWrapped = (wrappedData: InitialDataType<DataType>) => {
+    if (isWrappedData(wrappedData)) return wrappedData?.data;
+
+    return wrappedData;
+  };
+
+  const onIntersect: IntersectionObserverCallback = async ([entry]) => {
+    if (entry.isIntersecting) {
+      const fetchResult = await fetchFn(offsetIndex.current);
+      offsetIndex.current += 1;
+      const nextData = isWrappedData(fetchResult) ? fetchResult.data : fetchResult;
+
+      if (!nextData) {
+        setIsLoading(true);
+        return;
+      }
+
+      if (nextData.length === 0) {
+        setIsLastData(true);
+        return;
+      }
+
+      nextData.length > 0 && setData((prevData) => [...prevData, ...nextData]);
+      setIsLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    if (initialData) {
+      const nextData = unwrapDataIfWrapped(initialData);
+      setData(nextData || []);
+    }
+  }, [initialData]);
+
+  useEffect(() => {
+    let observer: IntersectionObserver | undefined = undefined;
+
+    if (loadPointRef && loadPointRef.current) {
+      observer = new IntersectionObserver(onIntersect, { root, rootMargin, threshold });
+      observer.observe(loadPointRef.current);
+    }
+
+    if (isLastData && observer) {
+      observer.disconnect();
+    }
+
+    return () => observer && observer.disconnect();
+  }, [rootMargin, threshold, initialData, fetchFn, isLastData]);
+
+  return { loadPointRef, isLoading, data };
+};
+
+export default useInfiniteQuery;

--- a/src/hooks/useInfiniteQuery.tsx
+++ b/src/hooks/useInfiniteQuery.tsx
@@ -60,13 +60,10 @@ const useInfiniteQuery = <DataType,>(
 
   const renderCurrentData = () => {
     if (!renderFn) return;
-    return (
-      <>
-        {data && data.length > 0 && renderFn(data)}
-        <LoadPoint ref={loadPointRef}>{isLoading && <Loader />}</LoadPoint>
-      </>
-    );
+    return data && data.length > 0 && renderFn(data);
   };
+
+  const loadPoint = <LoadPoint ref={loadPointRef}>{isLoading && <Loader />}</LoadPoint>;
 
   useEffect(() => {
     if (initialData) {
@@ -92,18 +89,11 @@ const useInfiniteQuery = <DataType,>(
     return () => observer && observer.disconnect();
   }, [root, rootMargin, threshold, initialData, fetchFn, isLastData, onIntersect]);
 
-  return { loadPointRef, isLoading, data, renderCurrentData };
+  return { isLoading, data, renderCurrentData, loadPoint };
 };
 
 const LoadPoint = styled.span`
-  position: absolute;
-  bottom: 0;
-  left: 50%;
-  transform: translate(-50%, -50%);
-
-  height: 100px;
-
-  margin-bottom: 8rem;
+  position: relative;
 `;
 
 export default useInfiniteQuery;

--- a/src/hooks/useInfiniteQuery.tsx
+++ b/src/hooks/useInfiniteQuery.tsx
@@ -17,8 +17,8 @@ interface WrappedData<DataType> {
 const useInfiniteQuery = <DataType,>(
   initialData: InitialDataType<DataType>,
   fetchFn: (offset: number) => Promise<InitialDataType<DataType>> | InitialDataType<DataType>,
-  props: IUseObserver,
-  renderFn?: (currentData: DataType[]) => React.ReactNode,
+  renderFn: (currentData: DataType[]) => React.ReactNode,
+  props: IUseObserver = {},
 ) => {
   const isWrappedData = (data: InitialDataType<DataType>): data is WrappedData<DataType> =>
     data !== undefined && 'data' in data;
@@ -32,11 +32,11 @@ const useInfiniteQuery = <DataType,>(
   const loadPointRef = useRef(null);
   const offsetIndex = useRef(1);
 
-  const unwrapDataIfWrapped = (wrappedData: InitialDataType<DataType>) => {
+  const unwrapDataIfWrapped = useCallback((wrappedData: InitialDataType<DataType>) => {
     if (isWrappedData(wrappedData)) return wrappedData?.data;
 
     return wrappedData;
-  };
+  }, []);
 
   const onIntersect: IntersectionObserverCallback = useCallback(async ([entry]) => {
     if (entry.isIntersecting) {
@@ -75,7 +75,7 @@ const useInfiniteQuery = <DataType,>(
       setIsLastData(false);
       offsetIndex.current = 1;
     }
-  }, [initialData]);
+  }, [initialData, unwrapDataIfWrapped]);
 
   useEffect(() => {
     if (!initialData) return;

--- a/src/map/overlays/tooltip.tsx
+++ b/src/map/overlays/tooltip.tsx
@@ -148,7 +148,6 @@ export const getToolTipTemplate = (
     e.preventDefault();
     navigate(`/shop/detail/${shopId}`);
   };
-  console.log(shopName, new Blob([shopName + parseCategorySafely(category)]).size);
   if (new Blob([shopName + parseCategorySafely(category)]).size > LONG_CONTENT) {
     tooltip.classList.add('long');
   }

--- a/src/pages/shop/collect.tsx
+++ b/src/pages/shop/collect.tsx
@@ -5,6 +5,7 @@ import ShopCard from 'components/common/ShopCard';
 import { shopApi, useGetShopByBookmarkQuery } from 'features/shops/shopApi';
 import { selectIsLogin } from 'features/users/userSlice';
 import useInfiniteQuery from 'hooks/useInfiniteQuery';
+import uniqBy from 'lodash-es/uniqBy';
 import { useCallback, useState } from 'react';
 import styled from 'styled-components';
 import { applyMediaQuery } from 'styles/mediaQuery';
@@ -12,6 +13,7 @@ import { theme } from 'styles/theme';
 import { ShopBookMarkRequestType, ShopResponse } from 'types/shop';
 
 const emptyContentData = {
+  title: '저장한 소품샵',
   src: '/assets/img_shopNoContent.png',
   label: '아직 저장한 소품샵이 없어요',
   subLabel: '취향저격 소품샵 찾으러 가볼까요?',
@@ -46,10 +48,11 @@ function Collect() {
     [currentSort],
   );
 
-  const { data, renderCurrentData } = useInfiniteQuery<ShopResponse>(
+  const { data, renderCurrentData, loadPoint } = useInfiniteQuery<ShopResponse>(
     collectShopList,
     fetchFn,
-    (shopList) => shopList.map((shop) => <ShopCard key={shop.shopId} cardData={shop} />),
+    (shopList) =>
+      uniqBy(shopList, 'shopId').map((shop) => <ShopCard key={shop.shopId} cardData={shop} />),
   );
 
   const filterProps = [
@@ -69,14 +72,18 @@ function Collect() {
 
   return (
     <StyledContainer>
-      <>
-        <StyledFilterWrapper>
-          <h2>저장한 소품샵</h2>
-          <DropDownFilter pageType="collect" filterProps={filterProps} />
-        </StyledFilterWrapper>
-        <StyledCardWrapper>{renderCurrentData()}</StyledCardWrapper>
-        {!data && <EmptyContent emptyContentData={emptyContentData} />}
-      </>
+      {data.length === 0 ? (
+        <EmptyContent emptyContentData={emptyContentData} />
+      ) : (
+        <>
+          <StyledFilterWrapper>
+            <h2>저장한 소품샵</h2>
+            <DropDownFilter pageType="collect" filterProps={filterProps} />
+          </StyledFilterWrapper>
+          <StyledCardWrapper>{renderCurrentData()}</StyledCardWrapper>
+        </>
+      )}
+      {loadPoint}
     </StyledContainer>
   );
 }

--- a/src/pages/shop/collect.tsx
+++ b/src/pages/shop/collect.tsx
@@ -1,7 +1,6 @@
 import { useAppSelector } from 'app/hook';
 import DropDownFilter from 'components/common/DropDownFilter';
 import EmptyContent from 'components/common/EmptyContent';
-import Loader from 'components/common/Loader';
 import ShopCard from 'components/common/ShopCard';
 import { shopApi, useGetShopByBookmarkQuery } from 'features/shops/shopApi';
 import { selectIsLogin } from 'features/users/userSlice';
@@ -11,8 +10,6 @@ import styled from 'styled-components';
 import { applyMediaQuery } from 'styles/mediaQuery';
 import { theme } from 'styles/theme';
 import { ShopBookMarkRequestType, ShopResponse } from 'types/shop';
-
-import { LoadPoint as PrevLoadPoint } from './theme/[type]';
 
 const emptyContentData = {
   src: '/assets/img_shopNoContent.png',
@@ -49,10 +46,11 @@ function Collect() {
     [currentSort],
   );
 
-  const { data, isLoading, loadPointRef } = useInfiniteQuery<ShopResponse>(
+  const { data, renderCurrentData } = useInfiniteQuery<ShopResponse>(
     collectShopList,
     fetchFn,
     {},
+    (shopList) => shopList.map((shop) => <ShopCard key={shop.shopId} cardData={shop} />),
   );
 
   const filterProps = [
@@ -77,16 +75,7 @@ function Collect() {
           <h2>저장한 소품샵</h2>
           <DropDownFilter pageType="collect" filterProps={filterProps} />
         </StyledFilterWrapper>
-        <StyledCardWrapper>
-          {data && data.length > 0 && (
-            <>
-              {data.map((shop) => (
-                <ShopCard key={shop.shopId} cardData={shop} />
-              ))}
-            </>
-          )}
-          <LoadPoint ref={loadPointRef}>{isLoading && <Loader />}</LoadPoint>
-        </StyledCardWrapper>
+        <StyledCardWrapper>{renderCurrentData()}</StyledCardWrapper>
         {!data && <EmptyContent emptyContentData={emptyContentData} />}
       </>
     </StyledContainer>
@@ -165,12 +154,4 @@ const StyledCardWrapper = styled.div`
     grid-template-columns: repeat(2, 1fr);
     gap: 1.6rem 0.6rem;
   }
-`;
-
-const LoadPoint = styled(PrevLoadPoint)`
-  position: absolute;
-  bottom: 0;
-  left: 50%;
-
-  transform: translate(-50%, 200%);
 `;

--- a/src/pages/shop/collect.tsx
+++ b/src/pages/shop/collect.tsx
@@ -49,7 +49,6 @@ function Collect() {
   const { data, renderCurrentData } = useInfiniteQuery<ShopResponse>(
     collectShopList,
     fetchFn,
-    {},
     (shopList) => shopList.map((shop) => <ShopCard key={shop.shopId} cardData={shop} />),
   );
 

--- a/src/pages/shop/theme/[type].tsx
+++ b/src/pages/shop/theme/[type].tsx
@@ -226,7 +226,7 @@ const DropDownWrapper = styled.div`
   }
 `;
 
-const LoadPoint = styled.div`
+export const LoadPoint = styled.div`
   position: relative;
   height: 100px;
   margin-bottom: 8rem;

--- a/src/pages/shop/theme/[type].tsx
+++ b/src/pages/shop/theme/[type].tsx
@@ -226,7 +226,7 @@ const DropDownWrapper = styled.div`
   }
 `;
 
-export const LoadPoint = styled.div`
+export const LoadPoint = styled.span`
   position: relative;
   height: 100px;
   margin-bottom: 8rem;


### PR DESCRIPTION
<!-- PR의 제목은 "[#이슈번호] 이슈이름" 으로 작성해주시면 되겠습니다 -->

* closes #194 

## ✨ 구현 기능 명세

소희가 만든 useObserver을 확장시켜 useInfiniteQuery를 만들었어요
페이지 파일에서 무한스크롤 로직이 중복되어서 나타나는게 싫어서... 분리했습니다

그런데 생각보다 덩치가 커졌네요 ㅎ;

내가작성한다른리뷰/내가스크랩한다른리뷰 같은 경우에는 서버 API에서 페이지네이션 기능이 없어서 클라에서 임의로 페이지를 나누어 무한스크롤 구현했습니다~

## 😭 어려웠던 점

로딩을 불러오는 시점 -> loadpoint가 intersect되는 시점인데 커스텀훅으로빼니까 이게 조금씩 달랐던 점!
