### PR TITLE
Hotfix 220815/hj

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "axios": "0.24.0",
     "babel-plugin-inline-react-svg": "2.0.1",
     "lodash-es": "^4.17.21",
+    "logrocket": "^3.0.1",
     "next": "12.0.8-canary.19",
     "next-redux-wrapper": "7.0.5",
     "react": "17.0.2",

--- a/src/components/LocalShopInfo/ShopElement.tsx
+++ b/src/components/LocalShopInfo/ShopElement.tsx
@@ -1,3 +1,4 @@
+import useToast from 'hooks/useToast';
 import DelimiterIC from 'public/assets/ic_delimiter.svg';
 import loadImageSafely from 'src/utils/loadImageSafely';
 import parseCategorySafely from 'src/utils/parseCategorySafely';
@@ -14,17 +15,23 @@ function ShopElement({
   moveByAddress,
 }: {
   shopInfo: ShopAreaResponse;
-  moveByAddress: (landAddress: string, shopName: string) => void;
+  moveByAddress: (landAddress: string, shopName: string) => boolean;
 }) {
   const { shopName, category, image, landAddress, time, reviewCount } = shopInfo;
+  const { toast, fireToast } = useToast();
+
+  const handleElementWithMarker = () => {
+    const isSuccess = moveByAddress(landAddress, shopName);
+    if (isSuccess) {
+      scrollTo(0, 0);
+      return;
+    }
+
+    fireToast('소품샵 위치정보를 가져오는데 실패했어요.');
+  };
 
   return (
-    <StyledShopElement
-      onClick={() => {
-        moveByAddress(landAddress, shopName);
-        scrollTo(0, 0);
-      }}
-    >
+    <StyledShopElement onClick={handleElementWithMarker}>
       <ShopLeftWrapper>
         <ShopMainInfo>
           <h2>{shopName}</h2>
@@ -38,6 +45,7 @@ function ShopElement({
         </ShopSubInfo>
       </ShopLeftWrapper>
       <ShopImage src={loadImageSafely(image)} />
+      {toast}
     </StyledShopElement>
   );
 }

--- a/src/components/LocalShopInfo/ShopList.tsx
+++ b/src/components/LocalShopInfo/ShopList.tsx
@@ -17,7 +17,7 @@ function ShopList({
 }: {
   shopList: ShopAreaResponse[];
   isSaveOption: boolean;
-  moveByAddress: (landAddress: string, shopName: string) => void;
+  moveByAddress: (landAddress: string, shopName: string) => boolean;
   isLoading: boolean;
 }) {
   const router = useRouter();

--- a/src/components/LocalShopInfo/index.tsx
+++ b/src/components/LocalShopInfo/index.tsx
@@ -12,7 +12,7 @@ interface LocalShopInfoProps {
   currentOption: OptionLabel;
   shopList: ShopAreaResponse[];
   toggleOption: (option: OptionLabel) => void;
-  moveByAddress: (landAddress: string, shopName: string) => void;
+  moveByAddress: (landAddress: string, shopName: string) => boolean;
   isLoading: boolean;
 }
 

--- a/src/hooks/useMap.tsx
+++ b/src/hooks/useMap.tsx
@@ -77,8 +77,14 @@ function useMap<T>(
           if (targetMarker.setPage && targetMarkerIndex >= 0) {
             targetMarker.setPage(targetMarkerIndex);
           }
+
+          return true;
         }
+
+        return false;
       }
+
+      return false;
     },
     [map, currentMarkerList, isStaticMarker, isSmallDevice],
   );

--- a/src/map/overlays/tooltip.tsx
+++ b/src/map/overlays/tooltip.tsx
@@ -148,7 +148,6 @@ export const getToolTipTemplate = (
     e.preventDefault();
     navigate(`/shop/detail/${shopId}`);
   };
-  console.log(shopName, new Blob([shopName + parseCategorySafely(category)]).size);
   if (new Blob([shopName + parseCategorySafely(category)]).size > LONG_CONTENT) {
     tooltip.classList.add('long');
   }

--- a/src/map/utils/display.ts
+++ b/src/map/utils/display.ts
@@ -1,5 +1,6 @@
 import type { PayloadAction } from '@reduxjs/toolkit';
 import { MarkerInfo } from 'features/map/mapSlice';
+import LogRocket from 'logrocket';
 import { getMiniToolTipTemplate } from 'map/overlays/miniTooltip';
 import { getPagedToolTipTemplate, getToolTipTemplate } from 'map/overlays/tooltip';
 import shortid from 'shortid';
@@ -79,7 +80,7 @@ export const displayMarkerWithArray = async (
           },
         ];
 
-      console.error(setteledPromise.reason);
+      LogRocket.warn(setteledPromise.reason);
 
       return acc;
     }, [] as MarkerOverlayDataType);

--- a/src/map/utils/display.ts
+++ b/src/map/utils/display.ts
@@ -8,6 +8,12 @@ import { Shop } from 'types/shop';
 
 import { getLocationByAddress } from './search';
 
+type MarkerOverlayDataType = Array<
+  Pick<Shop, 'shopName' | 'category' | 'landAddress' | 'shopId'> & {
+    latlng: KakaoLatLng | null;
+  }
+>;
+
 export const displayMarker = async (
   map: KakaoMap,
   shopInfo: Pick<Shop, 'shopName' | 'category' | 'landAddress' | 'shopId'>,
@@ -62,11 +68,21 @@ export const displayMarkerWithArray = async (
     const locationPromiseList = shopList.map(async ({ landAddress, shopName }) =>
       getLocationByAddress(landAddress, shopName),
     );
-    const locationList = await Promise.all(locationPromiseList);
-    const shopListWithMarkerPosition = shopList.map((shopInfo, infoIndex) => ({
-      ...shopInfo,
-      latlng: locationList[infoIndex],
-    }));
+    const settledPromises = await Promise.allSettled(locationPromiseList);
+    const shopListWithMarkerPosition = settledPromises.reduce((acc, setteledPromise, index) => {
+      if (setteledPromise.status === 'fulfilled')
+        return [
+          ...acc,
+          {
+            ...shopList[index],
+            latlng: setteledPromise.value,
+          },
+        ];
+
+      console.error(setteledPromise.reason);
+
+      return acc;
+    }, [] as MarkerOverlayDataType);
 
     /**
      * 동일한 좌표를 갖는 소품샵들을 배열로 그룹화하는 작업.

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -3,15 +3,22 @@ import Footer from 'components/common/Footer';
 import Layout from 'components/common/Layout';
 import NavBar from 'components/common/Navbar/GlobalNav';
 import useWindowSize from 'hooks/useWindowSize';
+import LogRocket from 'logrocket';
 import type { AppProps } from 'next/app';
 import Head from 'next/head';
 import Script from 'next/script';
+import { useEffect } from 'react';
 import { ThemeProvider } from 'styled-components';
 import GlobalStyles from 'styles/globalStyle';
 import { theme } from 'styles/theme';
 
 function MyApp({ Component, pageProps }: AppProps) {
   const { clientWidth, availableWidth } = useWindowSize();
+
+  useEffect(() => {
+    LogRocket.init('zkogtj/sodam');
+  }, []);
+
   return (
     <ThemeProvider theme={{ ...theme, clientWidth, availableWidth }}>
       <GlobalStyles />

--- a/yarn.lock
+++ b/yarn.lock
@@ -1729,6 +1729,11 @@ lodash@^4.17.11:
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
 
+logrocket@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/logrocket/-/logrocket-3.0.1.tgz#c746e8df3d5fee999b152975e51db1908357a6f0"
+  integrity sha512-jOWG+jEzobKVxGytzZ+4KGm2kiMQMRTHab2uDWQyVZcHfEF38BlCH1yjQVY4LCmuQUwZitP9biMzJZnyUQ0dtQ==
+
 loose-envify@^1.1.0, loose-envify@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.4.0.tgz#71ee51fa7be4caec1a63839f7e682d8132d30caf"


### PR DESCRIPTION
* closes #202 

<!-- PR의 제목은 "[#이슈번호] 이슈이름" 으로 작성해주시면 되겠습니다 -->

문제: 특정 행정구에서 소품샵 하나에 대한 검색이 실패해도 모든 마커가 나타나지 않음.
원인: 주소 검색결과를 Promise.all 로 받아오고있어서 하나만 실패해도 모두 실패된 것으로 처리됨.
해결: Promise.allSettled를 통해 성공한것에 대해서만 처리하고 실패한것은 로그를 남기도록 함.
+a) 소품샵 주소정보를 불러오지 못한 데이터를 클릭했을 경우에는 마커로의 이동 대신 토스트 메시지를 띄움(주소정보를 불러오지 못했음)
